### PR TITLE
fix(scoresheet): hide tie breaker when not needed and fix scoresheet select in add match

### DIFF
--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/TieBreakerDialog.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/TieBreakerDialog.tsx
@@ -33,6 +33,7 @@ import {
 import { ScrollArea } from "@board-games/ui/scroll-area";
 import { cn } from "@board-games/ui/utils";
 
+import { Spinner } from "~/components/spinner";
 import { useTRPC } from "~/trpc/react";
 
 export const TieBreakerPlayerSchema = z
@@ -355,7 +356,16 @@ function Content({
             )}
           />
           <AlertDialogFooter>
-            <Button type="submit">Finish</Button>
+            <Button type="submit" disabled={updateMatchPlacement.isPending}>
+              {updateMatchPlacement.isPending ? (
+                <>
+                  <Spinner />
+                  <span>Finishing...</span>
+                </>
+              ) : (
+                "Finish"
+              )}
+            </Button>
           </AlertDialogFooter>
         </form>
       </Form>

--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/match.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/match.tsx
@@ -264,7 +264,7 @@ export function Match({ matchId }: { matchId: number }) {
         playersPlacement
           .filter((player) => {
             const foundPlayer = players.find((p) => p.id === player.id);
-            return foundPlayer?.teamId === null;
+            return foundPlayer?.teamId !== null;
           })
           .map((player) => {
             {
@@ -287,12 +287,10 @@ export function Match({ matchId }: { matchId: number }) {
       ...nonTeamPlayerPlacements,
     ];
     for (const currentPlacement of teamAndPlayerPlacements) {
-      if (currentPlacement) {
-        placements[currentPlacement] = (placements[currentPlacement] ?? 0) + 1;
-        if (placements[currentPlacement] > 1) {
-          isTieBreaker = true;
-          break;
-        }
+      placements[currentPlacement] = (placements[currentPlacement] ?? 0) + 1;
+      if (placements[currentPlacement] > 1) {
+        isTieBreaker = true;
+        break;
       }
     }
     if (isTieBreaker) {

--- a/apps/nextjs/src/app/dashboard/games/[id]/_components/addMatch.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/_components/addMatch.tsx
@@ -100,12 +100,7 @@ export function AddMatchDialog({
     </Dialog>
   );
 }
-const formSchema = matchSchema.extend({
-  players: playersSchema,
-  location: locationSchema,
-  scoresheetId: z.number(),
-});
-type formSchemaType = z.infer<typeof formSchema>;
+
 function Content({
   matches,
   gameId,
@@ -119,6 +114,20 @@ function Content({
   defaultLocation: RouterOutputs["location"]["getDefaultLocation"];
   scoresheets: RouterOutputs["game"]["getGameScoresheets"];
 }) {
+  const formSchema = matchSchema.extend({
+    players: playersSchema,
+    location: locationSchema,
+    scoresheetId: z
+      .number()
+      .refine(
+        (scoresheetId) =>
+          scoresheets.find((scoresheet) => scoresheet.id === scoresheetId) !==
+          undefined,
+        { message: "Must select a scoresheet" },
+      ),
+  });
+  type formSchemaType = z.infer<typeof formSchema>;
+
   const trpc = useTRPC();
   const { isOpen, match, setMatch, setLocation, setScoresheetId, reset } =
     useAddMatchStore((state) => state);
@@ -163,6 +172,9 @@ function Content({
 
   useEffect(() => {
     if (!isOpen) reset();
+    return () => {
+      if (!isOpen) reset();
+    };
   }, [isOpen, reset]);
 
   const onSubmit = (values: formSchemaType) => {
@@ -352,14 +364,14 @@ function Content({
                 <FormLabel>Scoresheet:</FormLabel>
                 <Select
                   onValueChange={(e) => {
-                    field.onChange(e);
-                    setScoresheetId(Number(e));
+                    field.onChange(Number.parseInt(e));
+                    setScoresheetId(Number.parseInt(e));
                   }}
                   defaultValue={field.value.toString()}
                 >
                   <FormControl>
                     <SelectTrigger>
-                      <SelectValue placeholder="Select a verified email to display" />
+                      <SelectValue placeholder="Select a scoresheet" />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -1,5 +1,4 @@
 import type { SQL } from "drizzle-orm";
-import type { PgColumn } from "drizzle-orm/pg-core";
 import { TRPCError } from "@trpc/server";
 import { and, count, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";


### PR DESCRIPTION
## ✅ Checklist

- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- **feat(addMatch):** Refactor form schema and improve scoresheet selection validation
  - Move form schema definition into the Content component for better encapsulation.
  - Enhance scoresheet ID validation to ensure selected scoresheet exists in the fetched scoresheets.
  - Update scoresheet selection placeholder for clarity.
  - Add cleanup logic in useEffect to reset state when the dialog is closed.

- **fix(match):** Correct player team identification and streamline tie-breaker logic
  - Update player filtering logic to correctly identify players with assigned teams.
  - Simplify tie-breaker logic by removing unnecessary conditional checks, enhancing code readability.
  - Add a loading spinner to the TieBreakerDialog button to improve user feedback during match updates.


