### PR TITLE
feat(match, addGameDialog): improve scoresheet integration and validation logic

### DIFF
--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/match.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/match.tsx
@@ -490,6 +490,7 @@ export function Match({ matchId }: { matchId: number }) {
           matchId={match.id}
           players={manualWinners}
           teams={match.teams}
+          scoresheet={match.scoresheet}
         />
         <TieBreakerDialog
           isOpen={openTieBreakerDialog}

--- a/packages/api/src/routers/match.ts
+++ b/packages/api/src/routers/match.ts
@@ -780,30 +780,37 @@ export const matchRouter = createTRPCRouter({
           running: false,
         })
         .where(eq(match.id, input.matchId));
-      await ctx.db
-        .update(matchPlayer)
-        .set({ winner: false })
-        .where(
-          and(
-            eq(matchPlayer.matchId, input.matchId),
-            notInArray(
-              matchPlayer.id,
-              input.winners.map((winner) => winner.id),
+      if (input.winners.length > 0) {
+        await ctx.db
+          .update(matchPlayer)
+          .set({ winner: false })
+          .where(
+            and(
+              eq(matchPlayer.matchId, input.matchId),
+              notInArray(
+                matchPlayer.id,
+                input.winners.map((winner) => winner.id),
+              ),
             ),
-          ),
-        );
-      await ctx.db
-        .update(matchPlayer)
-        .set({ winner: true })
-        .where(
-          and(
-            eq(matchPlayer.matchId, input.matchId),
-            inArray(
-              matchPlayer.id,
-              input.winners.map((winner) => winner.id),
+          );
+        await ctx.db
+          .update(matchPlayer)
+          .set({ winner: true })
+          .where(
+            and(
+              eq(matchPlayer.matchId, input.matchId),
+              inArray(
+                matchPlayer.id,
+                input.winners.map((winner) => winner.id),
+              ),
             ),
-          ),
-        );
+          );
+      } else {
+        await ctx.db
+          .update(matchPlayer)
+          .set({ winner: false })
+          .where(eq(matchPlayer.matchId, input.matchId));
+      }
     }),
   updateMatchDuration: protectedUserProcedure
     .input(

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -107,7 +107,7 @@ export const scoreSheetSchema = insertScoreSheetSchema
     type: true,
     gameId: true,
   })
-  .required({ name: true });
+  .required({ name: true, isCoop: true });
 export const editScoresheetSchema = scoreSheetSchema.extend({
   isDefault: z.boolean().optional(),
 });


### PR DESCRIPTION
## ✅ Checklist

- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## 📜 Changelog

- Refactor `ManualWinnerDialog` to accept `scoresheet` as a prop for enhanced validation based on win conditions.
- Pass `scoresheet` data from `match` component to `ManualWinnerDialog` to maintain validation consistency.
- Update match API to conditionally handle winner updates based on scoresheet-defined rules.
- Add custom validation in `AddGameDialog` for cooperative scoresheet win conditions — allow only `"Manual"` or `"Target Score"`.
- Dynamically filter scoresheet selection based on `isCoop` status for better UX.
- Require `isCoop` in scoresheet schema to improve data integrity.


