### PR TITLE
feat(locations): implement shared location pages, dropdowns & request handling

### DIFF
--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/share/_components/share-match.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/share/_components/share-match.tsx
@@ -85,9 +85,7 @@ export default function ShareMatchPage({ matchId }: { matchId: number }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const { data: matchToShare } = useSuspenseQuery(
-    trpc.match.getMatchToShare.queryOptions(
-      { id: matchId },
-    ),
+    trpc.match.getMatchToShare.queryOptions({ id: matchId }),
   );
   const { data: friends } = useSuspenseQuery(
     trpc.friend.getFriends.queryOptions(),
@@ -356,9 +354,7 @@ export default function ShareMatchPage({ matchId }: { matchId: number }) {
                                         {friends.map((friend) => (
                                           <CommandItem
                                             key={friend.friendId}
-                                            value={
-                                              friend.friend.name ?? "Unknown"
-                                            }
+                                            value={friend.friendId.toString()}
                                             onSelect={() => {
                                               setSelectedFriends((current) => {
                                                 if (

--- a/apps/nextjs/src/app/dashboard/games/[id]/_components/game-detail.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/_components/game-detail.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { BarChart2, Dice1Icon as Dice, Dices } from "lucide-react";
+import { BarChart2, Dices } from "lucide-react";
 
 import { Badge } from "@board-games/ui/badge";
 import { Button } from "@board-games/ui/button";
@@ -85,8 +85,8 @@ export default function GameDetails({ gameId }: { gameId: number }) {
         <div className="absolute bottom-4 right-6 z-10 sm:right-10">
           <AddMatchDialog
             gameId={gameId}
-            gameName={game.name ?? "Game"}
-            matches={game.matches.length ?? 0}
+            gameName={game.name}
+            matches={game.matches.length}
           />
         </div>
       </div>

--- a/apps/nextjs/src/app/dashboard/games/[id]/add/location/_components/locationForm.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/add/location/_components/locationForm.tsx
@@ -118,7 +118,7 @@ export default function SelectLocationForm({
                                   </div>
 
                                   <div className="flex h-10 w-10 items-center justify-center rounded-sm bg-background">
-                                    {location.matches.length}
+                                    {location.matches}
                                   </div>
                                 </FormLabel>
                               </FormItem>

--- a/apps/nextjs/src/app/dashboard/games/[id]/edit/_components/editGameForm.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/edit/_components/editGameForm.tsx
@@ -35,6 +35,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@board-games/ui/alert-dialog";
+import { Badge } from "@board-games/ui/badge";
 import { Button } from "@board-games/ui/button";
 import {
   Card,
@@ -77,6 +78,8 @@ import { useUploadThing } from "~/utils/uploadthing";
 import { RoundPopOver } from "./roundPopOver";
 
 export const scoresheetSchema = editScoresheetSchema.extend({
+  scoresheetType: z.literal("original").or(z.literal("shared")),
+  permission: z.literal("view").or(z.literal("edit")).nullable(),
   scoresheetId: z.number().nullable(),
   rounds: roundsSchema,
   scoreSheetChanged: z.boolean(),
@@ -96,6 +99,7 @@ export function EditGameForm({
   >(
     data.scoresheets.map((scoresheet) => ({
       ...scoresheet,
+      permission: "permission" in scoresheet ? scoresheet.permission : null,
       scoresheetId: scoresheet.id,
       scoreSheetChanged: false,
       roundChanged: false,
@@ -136,6 +140,8 @@ export function EditGameForm({
           scoresheet={
             scoresheets[activeScoreSheet] ?? {
               scoresheetId: null,
+              permission: null,
+              scoresheetType: "original",
               name:
                 scoresheets.length === 0
                   ? "Default"
@@ -839,8 +845,22 @@ const GameForm = ({
                               setActiveScoreSheet(index);
                             }}
                             type="button"
+                            disabled={
+                              scoreSheet.scoresheetType === "shared" &&
+                              scoreSheet.permission === "view"
+                            }
                           >
-                            <span className="text-lg">{scoreSheet.name}</span>
+                            <div className="flex items-center gap-2">
+                              <span className="text-lg">{scoreSheet.name}</span>
+                              {scoreSheet.scoresheetType === "shared" && (
+                                <Badge
+                                  variant="outline"
+                                  className="bg-blue-600 text-xs"
+                                >
+                                  Shared
+                                </Badge>
+                              )}
+                            </div>
                             <div className="mb-2 flex w-full items-center gap-3 text-sm">
                               <div className="flex min-w-20 items-center gap-1">
                                 <span>Win Condition:</span>
@@ -871,6 +891,10 @@ const GameForm = ({
                               setActiveScoreSheet(index);
                               setOpenAlert(true);
                             }}
+                            disabled={
+                              scoreSheet.scoresheetType === "shared" &&
+                              scoreSheet.permission === "view"
+                            }
                           >
                             <Trash />
                           </Button>

--- a/apps/nextjs/src/app/dashboard/games/[id]/page.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/page.tsx
@@ -36,7 +36,6 @@ export default async function Page({ params }: Props) {
   void prefetch(
     trpc.game.getGameScoresheets.queryOptions({ gameId: Number(id) }),
   );
-  void prefetch(trpc.location.getDefaultLocation.queryOptions());
   return (
     <HydrateClient>
       <div className="container px-3 py-1 md:px-6 md:py-2">

--- a/apps/nextjs/src/app/dashboard/games/[id]/share/_components/share-game.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/share/_components/share-game.tsx
@@ -427,9 +427,7 @@ export default function ShareGamePage({ gameId }: { gameId: number }) {
                                         {friends.map((friend) => (
                                           <CommandItem
                                             key={friend.friendId}
-                                            value={
-                                              friend.friend.name ?? "Unknown"
-                                            }
+                                            value={friend.friendId.toString()}
                                             onSelect={() => {
                                               setSelectedFriends((current) => {
                                                 if (

--- a/apps/nextjs/src/app/dashboard/games/[id]/stats/_components/game-stats.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/stats/_components/game-stats.tsx
@@ -224,7 +224,17 @@ export default function GameStats({ gameId }: { gameId: number }) {
                   {lastMatch.location && (
                     <div className="flex items-center gap-2">
                       <MapPinIcon className="h-5 w-5" />
-                      <span>{lastMatch.location}</span>
+                      <span>{lastMatch.location.name}</span>
+                      {lastMatch.location.type === "linked" && (
+                        <Badge variant="outline" className="text-xs">
+                          Linked
+                        </Badge>
+                      )}
+                      {lastMatch.location.type === "shared" && (
+                        <Badge variant="outline" className="text-xs">
+                          Shared
+                        </Badge>
+                      )}
                     </div>
                   )}
                 </div>

--- a/apps/nextjs/src/app/dashboard/games/_components/game-card.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/game-card.tsx
@@ -1,7 +1,14 @@
 import Image from "next/image";
 import Link from "next/link";
 import { format } from "date-fns";
-import { CalendarIcon, Clock, Dices, GamepadIcon, Users } from "lucide-react";
+import {
+  CalendarIcon,
+  Clock,
+  Dices,
+  GamepadIcon,
+  MapPinIcon,
+  Users,
+} from "lucide-react";
 
 import type { RouterOutputs } from "@board-games/api";
 import { Badge } from "@board-games/ui/badge";
@@ -95,14 +102,26 @@ export function GameCard({ game }: GameCardProps) {
             </div>
             <GamesDropDown data={game} />
           </div>
-          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-            <div className="flex flex-shrink-0 items-center gap-1">
-              <Users className="h-3 w-3" />
-              <span>{playerCount()}</span>
+          <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              <div className="flex flex-shrink-0 items-center gap-1">
+                <Users className="h-3 w-3" />
+                <span>{playerCount()}</span>
+              </div>
+              <div className="flex flex-shrink-0 items-center gap-1">
+                <Clock className="h-3 w-3" />
+                <span>{playtime()}</span>
+              </div>
             </div>
-            <div className="flex flex-shrink-0 items-center gap-1">
-              <Clock className="h-3 w-3" />
-              <span>{playtime()}</span>
+            <div>
+              {game.lastPlayed.location && (
+                <div className="flex items-center gap-1">
+                  <MapPinIcon className="h-3 w-3 flex-shrink-0" />
+                  <span className="truncate">
+                    {game.lastPlayed.location.name}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
           <div className="mt-1 flex items-center justify-between text-xs text-muted-foreground">
@@ -115,9 +134,7 @@ export function GameCard({ game }: GameCardProps) {
             {formattedLastPlayed && (
               <div className="flex items-center gap-1">
                 <CalendarIcon className="h-3 w-3 flex-shrink-0" />
-                <span className="truncate" suppressHydrationWarning>
-                  {formattedLastPlayed}
-                </span>
+                <span suppressHydrationWarning>{formattedLastPlayed}</span>
               </div>
             )}
           </div>

--- a/apps/nextjs/src/app/dashboard/games/_components/games-list.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/games-list.tsx
@@ -152,6 +152,7 @@ function GamesList({ initialGames }: GamesListProps) {
     if (sortField === "lastPlayed") {
       return <CalendarClock className="mr-2 h-4 w-4" />;
     }
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (sortField === "matches") {
       return <GamepadIcon className="mr-2 h-4 w-4" />;
     }

--- a/apps/nextjs/src/app/dashboard/games/_components/match-player-stats.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/match-player-stats.tsx
@@ -1,5 +1,3 @@
-import { Trophy } from "lucide-react";
-
 import type { RouterOutputs } from "@board-games/api";
 import { getOrdinalSuffix } from "@board-games/shared";
 import { Badge } from "@board-games/ui/badge";

--- a/apps/nextjs/src/app/dashboard/games/_components/matches-list.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/matches-list.tsx
@@ -43,7 +43,10 @@ interface BaseMatch {
   date: Date;
   name: string;
   finished: boolean;
-  location: string | undefined;
+  location: {
+    type: "shared" | "linked" | "original";
+    name: string;
+  } | null;
   won: boolean;
   duration: number;
 }
@@ -90,7 +93,7 @@ export function MatchesList({ matches, isShared = false }: MatchesListProps) {
   useEffect(() => {
     const locations = new Set(
       matches
-        .map((match) => match.location)
+        .map((match) => match.location?.name)
         .filter((location) => location !== undefined),
     );
     setAvailableLocations(Array.from(locations));
@@ -105,7 +108,7 @@ export function MatchesList({ matches, isShared = false }: MatchesListProps) {
           const searchLower = searchQuery.toLowerCase();
           const nameMatch = match.name.toLowerCase().includes(searchLower);
           const locationMatch =
-            match.location?.toLowerCase().includes(searchLower) ?? false;
+            match.location?.name.toLowerCase().includes(searchLower) ?? false;
           if (!nameMatch && !locationMatch) return false;
         }
 
@@ -137,7 +140,10 @@ export function MatchesList({ matches, isShared = false }: MatchesListProps) {
         }
 
         // Location filter
-        if (locationFilter !== "all" && match.location !== locationFilter) {
+        if (
+          locationFilter !== "all" &&
+          match.location?.name !== locationFilter
+        ) {
           return false;
         }
 
@@ -494,7 +500,17 @@ export function MatchesList({ matches, isShared = false }: MatchesListProps) {
                         {match.location && (
                           <div className="flex items-center gap-1 text-sm sm:text-base">
                             <MapPinIcon className="h-4 w-4" />
-                            <span>{match.location}</span>
+                            <span>{match.location.name}</span>
+                            {match.location.type === "linked" && (
+                              <Badge variant="outline" className="text-xs">
+                                Linked
+                              </Badge>
+                            )}
+                            {match.location.type === "shared" && (
+                              <Badge variant="outline" className="text-xs">
+                                Shared
+                              </Badge>
+                            )}
                           </div>
                         )}
 

--- a/apps/nextjs/src/app/dashboard/games/shared/[id]/[matchId]/summary/_components/shared-match-summary.tsx
+++ b/apps/nextjs/src/app/dashboard/games/shared/[id]/[matchId]/summary/_components/shared-match-summary.tsx
@@ -83,10 +83,20 @@ export default function SharedMatchSummary({ matchId }: { matchId: number }) {
                     </span>
                   </div>
 
-                  {match.locationName && (
+                  {match.location && (
                     <div className="flex items-center gap-2">
                       <MapPinIcon className="h-4 w-4 text-muted-foreground" />
-                      <span>{match.locationName}</span>
+                      <span>{match.location.name}</span>
+                      {match.location.type === "linked" && (
+                        <Badge variant="outline" className="text-xs">
+                          Linked
+                        </Badge>
+                      )}
+                      {match.location.type === "shared" && (
+                        <Badge variant="outline" className="text-xs">
+                          Shared
+                        </Badge>
+                      )}
                     </div>
                   )}
 
@@ -136,7 +146,21 @@ export default function SharedMatchSummary({ matchId }: { matchId: number }) {
                       </div>
                       <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
                         <MapPinIcon className="h-4 w-4" />
-                        <span>{match.locationName}</span>
+                        {match.location && (
+                          <>
+                            <span>{match.location.name}</span>
+                            {match.location.type === "linked" && (
+                              <Badge variant="outline" className="text-xs">
+                                Linked
+                              </Badge>
+                            )}
+                            {match.location.type === "shared" && (
+                              <Badge variant="outline" className="text-xs">
+                                Shared
+                              </Badge>
+                            )}
+                          </>
+                        )}
                       </div>
 
                       <div className="mt-3 flex flex-wrap gap-2">

--- a/apps/nextjs/src/app/dashboard/games/shared/[id]/page.tsx
+++ b/apps/nextjs/src/app/dashboard/games/shared/[id]/page.tsx
@@ -16,7 +16,6 @@ export default async function SharedGamePage({ params }: Props) {
   void prefetch(
     trpc.game.getGameScoresheets.queryOptions({ gameId: Number(id) }),
   );
-  void prefetch(trpc.location.getDefaultLocation.queryOptions());
   return (
     <HydrateClient>
       <div className="container px-3 py-1 md:px-6 md:py-2">

--- a/apps/nextjs/src/app/dashboard/locations/[id]/page.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/[id]/page.tsx
@@ -17,6 +17,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   if (isNaN(Number(id))) redirect("/dashboard/locations");
   const location = await caller.location.getLocation({ id: Number(id) });
+  if (location === null) redirect("/dashboard/locations");
   return {
     title: location.name,
     description: `${location.name} Match Tracker`,
@@ -28,9 +29,6 @@ export default async function Page({ params }: Props) {
   const id = (await params).id;
 
   if (isNaN(Number(id))) redirect("/dashboard/locations");
-  void prefetch(
-    trpc.match.getMatchesByLocation.queryOptions({ locationId: Number(id) }),
-  );
   void prefetch(trpc.location.getLocation.queryOptions({ id: Number(id) }));
   return (
     <HydrateClient>

--- a/apps/nextjs/src/app/dashboard/locations/_components/editLocationDialog.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/_components/editLocationDialog.tsx
@@ -25,7 +25,6 @@ import {
 } from "@board-games/ui/form";
 import { useToast } from "@board-games/ui/hooks/use-toast";
 import { Input } from "@board-games/ui/input";
-import { Switch } from "@board-games/ui/switch";
 
 import { Spinner } from "~/components/spinner";
 import { useTRPC } from "~/trpc/react";
@@ -48,7 +47,6 @@ const locationSchema = z.object({
   name: z.string().min(1, {
     message: "Location name is required",
   }),
-  isDefault: z.boolean(),
 });
 const LocationContent = ({
   setOpen,
@@ -67,7 +65,6 @@ const LocationContent = ({
     resolver: zodResolver(locationSchema),
     defaultValues: {
       name: location.name,
-      isDefault: location.isDefault,
     },
   });
   const mutation = useMutation(
@@ -90,11 +87,17 @@ const LocationContent = ({
   );
   function onSubmit(values: z.infer<typeof locationSchema>) {
     setIsSubmitting(true);
-    mutation.mutate({
-      id: location.id,
-      name: values.name,
-      isDefault: values.isDefault,
-    });
+    if (location.type === "original") {
+      mutation.mutate({
+        id: location.id,
+        name: values.name,
+      });
+    } else {
+      mutation.mutate({
+        id: location.locationId,
+        name: values.name,
+      });
+    }
   }
   return (
     <>
@@ -116,23 +119,6 @@ const LocationContent = ({
               </FormItem>
             )}
           />
-          <FormField
-            control={form.control}
-            name="isDefault"
-            render={({ field }) => (
-              <FormItem className="flex w-full items-center justify-center gap-2">
-                <FormLabel>Is Default Location?</FormLabel>
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    aria-readonly
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
           <DialogFooter className="gap-2">
             <Button
               type="reset"
@@ -145,7 +131,7 @@ const LocationContent = ({
               {isSubmitting ? (
                 <>
                   <Spinner />
-                  <span>Submiting...</span>
+                  <span>Submitting...</span>
                 </>
               ) : (
                 "Submit"

--- a/apps/nextjs/src/app/dashboard/locations/_components/locationDropDown.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/_components/locationDropDown.tsx
@@ -85,12 +85,14 @@ export function LocationDropDown({
               View Stats
             </Link>
           </DropdownMenuItem>
-          <DialogTrigger asChild>
-            <DropdownMenuItem>Edit</DropdownMenuItem>
-          </DialogTrigger>
           <DropdownMenuItem onClick={onEditDefault}>
             {data.isDefault ? "Unset Default" : "Set Default"}
           </DropdownMenuItem>
+          {(data.type === "original" || data.permission === "edit") && (
+            <DialogTrigger asChild>
+              <DropdownMenuItem>Edit</DropdownMenuItem>
+            </DialogTrigger>
+          )}
           <DropdownMenuItem
             className="text-destructive focus:bg-destructive/80 focus:text-destructive-foreground"
             onClick={onDelete}

--- a/apps/nextjs/src/app/dashboard/locations/_components/locationDropDown.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/_components/locationDropDown.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { MoreVertical } from "lucide-react";
+import { BarChart2Icon, MoreVertical } from "lucide-react";
 
 import type { RouterOutputs } from "@board-games/api";
 import { Button } from "@board-games/ui/button";
@@ -24,6 +25,15 @@ export function LocationDropDown({
 }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const editDefaultLocation = useMutation(
+    trpc.location.editDefaultLocation.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(
+          trpc.location.getLocations.queryOptions(),
+        );
+      },
+    }),
+  );
   const deleteLocation = useMutation(
     trpc.location.deleteLocation.mutationOptions({
       onSuccess: async () => {
@@ -36,6 +46,21 @@ export function LocationDropDown({
   const onDelete = () => {
     deleteLocation.mutate({ id: data.id });
   };
+  const onEditDefault = () => {
+    if (data.type === "shared") {
+      editDefaultLocation.mutate({
+        id: data.id,
+        isDefault: !data.isDefault,
+        type: "shared",
+      });
+    } else {
+      editDefaultLocation.mutate({
+        id: data.id,
+        isDefault: !data.isDefault,
+        type: "original",
+      });
+    }
+  };
   const [isOpen, setIsOpen] = useState(false);
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -47,9 +72,25 @@ export function LocationDropDown({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
+          <DropdownMenuItem asChild>
+            <Link
+              href={
+                data.type === "shared"
+                  ? `/dashboard/location/shared/${data.id}/stats`
+                  : `/dashboard/location/${data.id}/stats`
+              }
+              className="flex items-center gap-2"
+            >
+              <BarChart2Icon className="mr-2 h-4 w-4" />
+              View Stats
+            </Link>
+          </DropdownMenuItem>
           <DialogTrigger asChild>
             <DropdownMenuItem>Edit</DropdownMenuItem>
           </DialogTrigger>
+          <DropdownMenuItem onClick={onEditDefault}>
+            {data.isDefault ? "Unset Default" : "Set Default"}
+          </DropdownMenuItem>
           <DropdownMenuItem
             className="text-destructive focus:bg-destructive/80 focus:text-destructive-foreground"
             onClick={onDelete}

--- a/apps/nextjs/src/app/dashboard/locations/_components/locationDropDown.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/_components/locationDropDown.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import Link from "next/link";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { BarChart2Icon, MoreVertical } from "lucide-react";
+import { MoreVertical } from "lucide-react";
 
 import type { RouterOutputs } from "@board-games/api";
 import { Button } from "@board-games/ui/button";
@@ -44,7 +43,7 @@ export function LocationDropDown({
     }),
   );
   const onDelete = () => {
-    deleteLocation.mutate({ id: data.id });
+    deleteLocation.mutate({ id: data.id, type: data.type });
   };
   const onEditDefault = () => {
     if (data.type === "shared") {
@@ -72,19 +71,6 @@ export function LocationDropDown({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
-            <Link
-              href={
-                data.type === "shared"
-                  ? `/dashboard/location/shared/${data.id}/stats`
-                  : `/dashboard/location/${data.id}/stats`
-              }
-              className="flex items-center gap-2"
-            >
-              <BarChart2Icon className="mr-2 h-4 w-4" />
-              View Stats
-            </Link>
-          </DropdownMenuItem>
           <DropdownMenuItem onClick={onEditDefault}>
             {data.isDefault ? "Unset Default" : "Set Default"}
           </DropdownMenuItem>

--- a/apps/nextjs/src/app/dashboard/locations/_components/locationsTable.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/_components/locationsTable.tsx
@@ -2,23 +2,22 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { MapPin, Search } from "lucide-react";
 
-import type { RouterOutputs } from "@board-games/api";
 import { Button } from "@board-games/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@board-games/ui/card";
 import { Input } from "@board-games/ui/input";
 import { ScrollArea } from "@board-games/ui/scroll-area";
 import { cn } from "@board-games/ui/utils";
 
+import { useTRPC } from "~/trpc/react";
 import { AddLocationDialog } from "./addLocationDialog";
 import { LocationDropDown } from "./locationDropDown";
 
-export function LocationsTable({
-  data,
-}: {
-  data: RouterOutputs["location"]["getLocations"];
-}) {
+export function LocationsTable() {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(trpc.location.getLocations.queryOptions());
   const [locations, setLocations] = useState(data);
   const [search, setSearch] = useState("");
   const filteredLocations = useMemo(() => {
@@ -62,7 +61,11 @@ export function LocationsTable({
               >
                 <CardContent className="flex w-full items-center justify-between gap-2 p-3 pt-3">
                   <Link
-                    href={`/dashboard/locations/${location.id}`}
+                    href={
+                      location.type === "shared"
+                        ? `/dashboard/locations/shared/${location.id}`
+                        : `/dashboard/locations/${location.id}`
+                    }
                     className="flex items-center gap-2"
                   >
                     <div className="relative flex h-14 w-14 shrink-0 overflow-hidden rounded-full shadow">
@@ -71,12 +74,13 @@ export function LocationsTable({
                       </div>
                     </div>
                     <div className="flex flex-col gap-2">
-                      <div className="flex w-full items-center justify-between">
+                      <div className="flex w-full items-center gap-2">
                         <h2 className="text-md text-left font-semibold">
                           {`${location.name}`}
                         </h2>
-                        {location.isDefault && (
-                          <span className="pl-2">{"(Default)"}</span>
+                        {location.isDefault && <span>{"(Default)"}</span>}
+                        {location.type === "shared" && (
+                          <span className="text-blue-500">{`(Shared)`}</span>
                         )}
                       </div>
                     </div>
@@ -84,7 +88,7 @@ export function LocationsTable({
 
                   <div className="flex items-center justify-center gap-4">
                     <Button size={"icon"} variant={"outline"}>
-                      {location.matches.length}
+                      {location.matches}
                     </Button>
                     <LocationDropDown data={location} />
                   </div>

--- a/apps/nextjs/src/app/dashboard/locations/page.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-import { caller, HydrateClient } from "~/trpc/server";
+import { HydrateClient, prefetch, trpc } from "~/trpc/server";
 import { LocationsTable } from "./_components/locationsTable";
 
 export const metadata: Metadata = {
@@ -9,13 +9,13 @@ export const metadata: Metadata = {
   icons: [{ rel: "icon", url: "/map-pin.ico" }],
 };
 
+// eslint-disable-next-line @typescript-eslint/require-await
 export default async function Page() {
-  const locations = await caller.location.getLocations();
-  //TODO add shared matches
+  void prefetch(trpc.location.getLocations.queryOptions());
   return (
     <HydrateClient>
       <div className="flex w-full items-center justify-center">
-        <LocationsTable data={locations} />
+        <LocationsTable />
       </div>
     </HydrateClient>
   );

--- a/apps/nextjs/src/app/dashboard/locations/shared/[id]/page.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/shared/[id]/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+
+import { Table, TableBody } from "@board-games/ui/table";
+
+import { caller, HydrateClient, prefetch, trpc } from "~/trpc/server";
+import { Matches, MatchSkeleton } from "./_components/Matches";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  // read route params
+  const id = (await params).id;
+
+  if (isNaN(Number(id))) redirect("/dashboard/locations");
+  const location = await caller.sharing.getSharedLocation({ id: Number(id) });
+  if (location === null) redirect("/dashboard/locations");
+  return {
+    title: location.name,
+    description: `${location.name} Match Tracker`,
+    icons: [{ rel: "icon", url: "/map-pin.ico" }],
+  };
+}
+
+export default async function Page({ params }: Props) {
+  const id = (await params).id;
+
+  if (isNaN(Number(id))) redirect("/dashboard/locations");
+  void prefetch(
+    trpc.sharing.getSharedLocation.queryOptions({ id: Number(id) }),
+  );
+  return (
+    <HydrateClient>
+      <div className="flex w-full items-center justify-center">
+        <Suspense
+          fallback={
+            <div className="container relative mx-auto h-[90vh] max-w-3xl px-4">
+              <Table className="flex flex-col gap-2">
+                <TableBody>
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <MatchSkeleton key={i} />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          }
+        >
+          <Matches locationId={Number(id)} />
+        </Suspense>
+      </div>
+    </HydrateClient>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/players/[id]/share/_components/share-player.tsx
+++ b/apps/nextjs/src/app/dashboard/players/[id]/share/_components/share-player.tsx
@@ -375,9 +375,7 @@ export default function SharePlayerPage({ playerId }: { playerId: number }) {
                                         {friends.map((friend) => (
                                           <CommandItem
                                             key={friend.friendId}
-                                            value={
-                                              friend.friend.name ?? "Unknown"
-                                            }
+                                            value={friend.friendId.toString()}
                                             onSelect={() => {
                                               setSelectedFriends((current) => {
                                                 if (

--- a/apps/nextjs/src/app/dashboard/share-requests/[id]/_componenets/child-locations-request.tsx
+++ b/apps/nextjs/src/app/dashboard/share-requests/[id]/_componenets/child-locations-request.tsx
@@ -1,0 +1,388 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Check, ChevronDown, ThumbsDown, ThumbsUp } from "lucide-react";
+
+import type { RouterOutputs } from "@board-games/api";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@board-games/ui/accordion";
+import { Badge } from "@board-games/ui/badge";
+import { Button } from "@board-games/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@board-games/ui/command";
+import { Label } from "@board-games/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@board-games/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@board-games/ui/radio-group";
+import { ScrollArea } from "@board-games/ui/scroll-area";
+import { cn } from "@board-games/ui/utils";
+
+import { useTRPC } from "~/trpc/react";
+
+type LocationChildItem = Extract<
+  Extract<
+    RouterOutputs["sharing"]["getShareRequest"],
+    { itemType: "game" }
+  >["childItems"][number],
+  {
+    itemType: "location";
+  }
+>;
+type Locations = LocationChildItem[];
+
+interface LocationState {
+  sharedId: number;
+  accept: boolean;
+  linkedId: number | null;
+}
+
+export default function ChildLocationsRequest({
+  childLocations,
+  locations,
+  setLocations,
+}: {
+  childLocations: Locations;
+  locations: LocationState[];
+  setLocations: Dispatch<SetStateAction<LocationState[]>>;
+}) {
+  const trpc = useTRPC();
+
+  const { data: userLocations } = useSuspenseQuery(
+    trpc.sharing.getUserLocationsForLinking.queryOptions(),
+  );
+
+  useEffect(() => {
+    setLocations(
+      childLocations.map((location) => ({
+        sharedId: location.shareId,
+        accept: true,
+        linkedId: null,
+      })),
+    );
+  }, [childLocations, setLocations]);
+  const updateLocationAcceptance = (locationId: number, accept: boolean) => {
+    const temp = locations.map((location) => {
+      if (location.sharedId === locationId) {
+        return {
+          ...location,
+          accept,
+        };
+      }
+      return location;
+    });
+    setLocations(temp);
+  };
+  const updateLocationLink = (locationId: number, linkedId: number | null) => {
+    const temp = locations.map((location) => {
+      if (location.sharedId === locationId) {
+        return {
+          ...location,
+          linkedId,
+        };
+      }
+      return location;
+    });
+    setLocations(temp);
+  };
+  const possibleMatches = useMemo(() => {
+    return childLocations.reduce((acc, curr) => {
+      const foundLocation = userLocations.find(
+        (l) => l.name.toLowerCase() === curr.item.name.toLowerCase(),
+      );
+      if (foundLocation) {
+        return acc + 1;
+      }
+      return acc;
+    }, 0);
+  }, [childLocations, userLocations]);
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-medium">Locations</h3>
+          <span className="font-medium text-green-600">
+            {possibleMatches > 0 &&
+              ` (${possibleMatches} possible ${possibleMatches === 1 ? "match" : "matches"})`}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {locations.reduce((acc, curr) => {
+            if (curr.accept) return acc + 1;
+            return acc;
+          }, 0)}{" "}
+          of {childLocations.length} selected
+        </p>
+      </div>
+      <ScrollArea className="p-2">
+        <div className="grid max-h-[20rem] gap-2">
+          {childLocations
+            .toSorted((a, b) => {
+              return (
+                userLocations.filter(
+                  (l) => l.name.toLowerCase() === b.item.name.toLowerCase(),
+                ).length -
+                userLocations.filter(
+                  (l) => l.name.toLowerCase() === a.item.name.toLowerCase(),
+                ).length
+              );
+            })
+            .map((locationItem) => {
+              const isAccepted =
+                locations.find((l) => l.sharedId === locationItem.shareId)
+                  ?.accept ?? false;
+              const locationState = locations.find(
+                (l) => l.sharedId === locationItem.shareId,
+              );
+              if (!locationState) return null;
+              const foundLocation = userLocations.find(
+                (l) =>
+                  l.name.toLowerCase() === locationItem.item.name.toLowerCase(),
+              );
+              return (
+                <LocationRequest
+                  key={locationItem.item.id}
+                  location={locationItem}
+                  isAccepted={isAccepted}
+                  locationState={locationState}
+                  foundLocation={foundLocation}
+                  userLocations={userLocations}
+                  updateLocationAcceptance={updateLocationAcceptance}
+                  updateLocationLink={updateLocationLink}
+                />
+              );
+            })}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+function LocationRequest({
+  location,
+  isAccepted,
+  locationState,
+  foundLocation,
+  userLocations,
+  updateLocationAcceptance,
+  updateLocationLink,
+}: {
+  location: LocationChildItem;
+  isAccepted: boolean;
+  locationState: LocationState;
+  foundLocation:
+    | RouterOutputs["sharing"]["getUserLocationsForLinking"][number]
+    | undefined;
+  userLocations: RouterOutputs["sharing"]["getUserLocationsForLinking"];
+  updateLocationAcceptance: (locationId: number, accept: boolean) => void;
+  updateLocationLink: (locationId: number, linkedId: number | null) => void;
+}) {
+  const [locationSearchOpen, setLocationSearchOpen] = useState(false);
+  const [locationOption, setLocationOption] = useState(false);
+  const [locationSearchQuery, setLocationSearchQuery] = useState("");
+
+  const sortedLocations = useMemo(() => {
+    const temp = [...userLocations];
+    temp.sort((a, b) => {
+      if (a.name === b.name) return 0;
+      if (foundLocation?.id === a.id) return -1;
+      if (foundLocation?.id === b.id) return 1;
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    });
+    return temp;
+  }, [foundLocation?.id, userLocations]);
+  return (
+    <Accordion type="multiple" className="w-full">
+      <AccordionItem value={`location-${location.item.id}`}>
+        <div className="flex w-full items-center justify-between pr-4">
+          <AccordionTrigger className="hover:no-underline">
+            <div className="flex w-full text-left">
+              <span className="font-medium">{location.item.name} </span>
+              <span className="font-medium text-green-600">
+                {locationState.linkedId
+                  ? "(Linked)"
+                  : foundLocation
+                    ? " (Possible Duplicate Found)"
+                    : ""}
+              </span>
+            </div>
+          </AccordionTrigger>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant={location.permission === "edit" ? "default" : "secondary"}
+              className="text-xs"
+            >
+              {location.permission === "edit" ? "Edit" : "View"}
+            </Badge>
+            <div className="flex flex-col items-center justify-center gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant={locationState.accept ? "default" : "outline"}
+                size="sm"
+                className="w-24"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  updateLocationAcceptance(locationState.sharedId, true);
+                }}
+              >
+                <ThumbsUp className="mr-2 h-4 w-4" />
+                Accept
+              </Button>
+              <Button
+                type="button"
+                variant={locationState.accept ? "outline" : "default"}
+                size="sm"
+                className="w-24"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  updateLocationAcceptance(locationState.sharedId, false);
+                }}
+              >
+                <ThumbsDown className="mr-2 h-4 w-4" />
+                Reject
+              </Button>
+            </div>
+          </div>
+        </div>
+        <AccordionContent>
+          {isAccepted ? (
+            <div className="space-y-4 pb-4 pt-2">
+              <div className="space-y-3">
+                <Label>Link to existing location</Label>
+
+                <RadioGroup
+                  value={locationOption ? "existing" : "none"}
+                  onValueChange={(value) => {
+                    if (value === "none") {
+                      setLocationOption(false);
+                      updateLocationLink(locationState.sharedId, null);
+                    } else {
+                      setLocationOption(true);
+                    }
+                  }}
+                  className="space-y-3"
+                >
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem
+                      value="none"
+                      id={`location-${location.item.id}-none`}
+                    />
+                    <Label htmlFor={`location-${location.item.id}-none`}>
+                      Don't link (create as new location)
+                    </Label>
+                  </div>
+                  <div className="flex items-start space-x-2">
+                    <RadioGroupItem
+                      value="existing"
+                      id={`existing-${location.item.id}-location`}
+                      className="mt-1"
+                    />
+                    <div className="grid w-full gap-1.5">
+                      <Label
+                        htmlFor={`existing-${location.item.id}-location`}
+                        className="font-medium"
+                      >
+                        Link to an existing location
+                      </Label>
+                      <p className="mb-2 text-sm text-muted-foreground">
+                        Connect this shared location to a location you already
+                        have.
+                      </p>
+
+                      {locationOption && (
+                        <Popover
+                          open={locationSearchOpen}
+                          onOpenChange={setLocationSearchOpen}
+                        >
+                          <PopoverTrigger asChild>
+                            <Button
+                              variant="outline"
+                              role="combobox"
+                              aria-expanded={locationSearchOpen}
+                              className="justify-between"
+                            >
+                              {locationState.linkedId
+                                ? userLocations.find(
+                                    (existingLocation) =>
+                                      existingLocation.id ===
+                                      locationState.linkedId,
+                                  )?.name
+                                : "Select a location..."}
+                              <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                            </Button>
+                          </PopoverTrigger>
+                          <PopoverContent className="w-[300px] p-0">
+                            <Command>
+                              <CommandInput
+                                placeholder="Search locations..."
+                                value={locationSearchQuery}
+                                onValueChange={setLocationSearchQuery}
+                              />
+                              <CommandEmpty>No locations found.</CommandEmpty>
+                              <CommandList>
+                                <CommandGroup>
+                                  {sortedLocations.map((existingLocation) => (
+                                    <CommandItem
+                                      key={existingLocation.id}
+                                      value={existingLocation.id.toString()}
+                                      onSelect={() =>
+                                        updateLocationLink(
+                                          locationState.sharedId,
+                                          existingLocation.id,
+                                        )
+                                      }
+                                    >
+                                      <div className="flex items-center gap-2">
+                                        <p>{existingLocation.name}</p>
+                                        {existingLocation.name.toLowerCase() ===
+                                          location.item.name.toLowerCase() && (
+                                          <span className="text-xs text-green-600">
+                                            (Exact match)
+                                          </span>
+                                        )}
+                                      </div>
+                                      <Check
+                                        className={cn(
+                                          "ml-auto h-4 w-4",
+                                          locationState.linkedId ===
+                                            existingLocation.id
+                                            ? "opacity-100"
+                                            : "opacity-0",
+                                        )}
+                                      />
+                                    </CommandItem>
+                                  ))}
+                                </CommandGroup>
+                              </CommandList>
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                      )}
+                    </div>
+                  </div>
+                </RadioGroup>
+              </div>
+            </div>
+          ) : (
+            <div className="py-4 text-center text-sm text-muted-foreground">
+              This location will not be added to your collection.
+            </div>
+          )}
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/share-requests/[id]/_componenets/child-match-request.tsx
+++ b/apps/nextjs/src/app/dashboard/share-requests/[id]/_componenets/child-match-request.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { isSameDay } from "date-fns";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 
@@ -12,6 +12,7 @@ import {
 import { Badge } from "@board-games/ui/badge";
 import { Button } from "@board-games/ui/button";
 import { Label } from "@board-games/ui/label";
+import { ScrollArea } from "@board-games/ui/scroll-area";
 
 type ChildItem = Extract<
   RouterOutputs["sharing"]["getShareRequest"],
@@ -61,10 +62,27 @@ export default function ChildMatchesRequest({
       return isSameDay(matchDate, m.date);
     });
   };
+  const possibleMatches = useMemo(() => {
+    return childMatches.reduce((acc, curr) => {
+      const potentialMatches = gameMatches.filter((m) => {
+        return isSameDay(curr.item.date, m.date);
+      });
+      if (potentialMatches.length > 0) {
+        return acc + 1;
+      }
+      return acc;
+    }, 0);
+  }, [childMatches, gameMatches]);
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h3 className="text-lg font-medium">Matches</h3>
+        <div className="flex items-center gap-2">
+          <h3 className="text-lg font-medium">Matches</h3>
+          <span className="font-medium text-green-600">
+            {possibleMatches > 0 &&
+              ` (${possibleMatches} possible ${possibleMatches === 1 ? "match" : "matches"})`}
+          </span>
+        </div>
         <p className="text-sm text-muted-foreground">
           {matches.reduce((acc, curr) => {
             if (curr.accept) return acc + 1;
@@ -73,150 +91,169 @@ export default function ChildMatchesRequest({
           of {childMatches.length} selected
         </p>
       </div>
+      <ScrollArea className="p-2">
+        <div className="grid max-h-[20rem] gap-2">
+          {childMatches
+            .toSorted((a, b) => {
+              return (
+                potentialMatches(b.item.date).length -
+                potentialMatches(a.item.date).length
+              );
+            })
+            .map((matchItem) => {
+              const isAccepted =
+                matches.find((m) => m.sharedId === matchItem.shareId)?.accept ??
+                false;
+              const matchState = matches.find(
+                (m) => m.sharedId === matchItem.shareId,
+              );
+              if (!matchState) return null;
 
-      {childMatches.map((matchItem) => {
-        const isAccepted =
-          matches.find((m) => m.sharedId === matchItem.shareId)?.accept ??
-          false;
-        const matchState = matches.find(
-          (m) => m.sharedId === matchItem.shareId,
-        );
-        if (!matchState) return null;
-
-        return (
-          <Accordion key={matchItem.item.id} type="multiple" className="w-full">
-            <AccordionItem value={`match-${matchItem.item.id}`}>
-              <div className="flex w-full items-center justify-between pr-4">
-                <AccordionTrigger className="hover:no-underline">
-                  <div className="flex w-full">
-                    <div className="text-left">
-                      <span className="font-medium">
-                        {matchItem.item.name}{" "}
-                      </span>
-                      {potentialMatches(matchItem.item.date).length > 0 && (
-                        <span className="font-medium text-green-600">
-                          (Possible Match Found)
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </AccordionTrigger>
-                <div className="flex items-center gap-2">
-                  <Badge
-                    variant={
-                      matchItem.permission === "edit" ? "default" : "secondary"
-                    }
-                    className="text-xs"
-                  >
-                    {matchItem.permission === "edit" ? "Edit" : "View"}
-                  </Badge>
-                  <div className="flex flex-col items-center justify-center gap-2 sm:flex-row">
-                    <Button
-                      type="button"
-                      variant={matchState.accept ? "default" : "outline"}
-                      size="sm"
-                      className="w-24"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        updateMatchAcceptance(matchState.sharedId, true);
-                      }}
-                    >
-                      <ThumbsUp className="mr-2 h-4 w-4" />
-                      Accept
-                    </Button>
-                    <Button
-                      type="button"
-                      variant={matchState.accept ? "outline" : "default"}
-                      size="sm"
-                      className="w-24"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        updateMatchAcceptance(matchState.sharedId, false);
-                      }}
-                    >
-                      <ThumbsDown className="mr-2 h-4 w-4" />
-                      Reject
-                    </Button>
-                  </div>
-                </div>
-              </div>
-              <AccordionContent>
-                {isAccepted ? (
-                  <div className="space-y-4">
-                    {potentialMatches(matchItem.item.date).length > 0 ? (
-                      <div className="space-y-3">
-                        <Label>Link to existing match</Label>
-
-                        <div className="mt-2 text-sm font-medium">
-                          Potential matches on same date:
+              return (
+                <Accordion
+                  key={matchItem.item.id}
+                  type="multiple"
+                  className="w-full"
+                >
+                  <AccordionItem value={`match-${matchItem.item.id}`}>
+                    <div className="flex w-full items-center justify-between pr-4">
+                      <AccordionTrigger className="hover:no-underline">
+                        <div className="flex w-full">
+                          <div className="text-left">
+                            <span className="font-medium">
+                              {matchItem.item.name}{" "}
+                            </span>
+                            {potentialMatches(matchItem.item.date).length >
+                              0 && (
+                              <span className="font-medium text-green-600">
+                                (Possible Match Found)
+                              </span>
+                            )}
+                          </div>
                         </div>
-                        {potentialMatches(matchItem.item.date).map(
-                          (potentialMatch) => (
-                            <div
-                              key={potentialMatch.id}
-                              className="flex items-center justify-between space-x-2"
-                            >
-                              <Label
-                                htmlFor={`match-${matchItem.item.id}-link-${potentialMatch.id}`}
-                              >
-                                <div>
-                                  <p>{potentialMatch.name}</p>
-                                  <ul className="text-xs text-muted-foreground">
-                                    <li>
-                                      Date:{" "}
-                                      {new Date(
-                                        potentialMatch.date,
-                                      ).toLocaleDateString()}
-                                    </li>
-                                    {potentialMatch.location && (
-                                      <li>
-                                        {`Location: ${potentialMatch.location.name}`}
-                                      </li>
-                                    )}
-                                  </ul>
-                                </div>
-                              </Label>
-                              <Button
-                                value={potentialMatch.id.toString()}
-                                id={`match-${matchItem.item.id}-link-${potentialMatch.id}`}
-                                onClick={() =>
-                                  updateMatchAcceptance(
-                                    matchState.sharedId,
-                                    false,
-                                  )
-                                }
-                              >
-                                Same Match
-                              </Button>
-                            </div>
-                          ),
-                        )}
+                      </AccordionTrigger>
+                      <div className="flex items-center gap-2">
+                        <Badge
+                          variant={
+                            matchItem.permission === "edit"
+                              ? "default"
+                              : "secondary"
+                          }
+                          className="text-xs"
+                        >
+                          {matchItem.permission === "edit" ? "Edit" : "View"}
+                        </Badge>
+                        <div className="flex flex-col items-center justify-center gap-2 sm:flex-row">
+                          <Button
+                            type="button"
+                            variant={matchState.accept ? "default" : "outline"}
+                            size="sm"
+                            className="w-24"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              updateMatchAcceptance(matchState.sharedId, true);
+                            }}
+                          >
+                            <ThumbsUp className="mr-2 h-4 w-4" />
+                            Accept
+                          </Button>
+                          <Button
+                            type="button"
+                            variant={matchState.accept ? "outline" : "default"}
+                            size="sm"
+                            className="w-24"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              updateMatchAcceptance(matchState.sharedId, false);
+                            }}
+                          >
+                            <ThumbsDown className="mr-2 h-4 w-4" />
+                            Reject
+                          </Button>
+                        </div>
                       </div>
-                    ) : (
-                      <p className="text-sm italic text-muted-foreground">
-                        No matches found on{" "}
-                        {new Date(matchItem.item.date).toLocaleDateString()} for
-                        the selected game
-                      </p>
-                    )}
+                    </div>
+                    <AccordionContent>
+                      {isAccepted ? (
+                        <div className="space-y-4">
+                          {potentialMatches(matchItem.item.date).length > 0 ? (
+                            <div className="space-y-3">
+                              <Label>Link to existing match</Label>
 
-                    {gameMatches.length === 0 && (
-                      <p className="text-sm text-muted-foreground">
-                        This match will be added as a new match to your
-                        collection.
-                      </p>
-                    )}
-                  </div>
-                ) : (
-                  <div className="py-2 text-center text-sm text-muted-foreground">
-                    This match will not be added to your collection.
-                  </div>
-                )}
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        );
-      })}
+                              <div className="mt-2 text-sm font-medium">
+                                Potential matches on same date:
+                              </div>
+                              {potentialMatches(matchItem.item.date).map(
+                                (potentialMatch) => (
+                                  <div
+                                    key={potentialMatch.id}
+                                    className="flex items-center justify-between space-x-2"
+                                  >
+                                    <Label
+                                      htmlFor={`match-${matchItem.item.id}-link-${potentialMatch.id}`}
+                                    >
+                                      <div>
+                                        <p>{potentialMatch.name}</p>
+                                        <ul className="text-xs text-muted-foreground">
+                                          <li>
+                                            Date:{" "}
+                                            {new Date(
+                                              potentialMatch.date,
+                                            ).toLocaleDateString()}
+                                          </li>
+                                          {potentialMatch.location && (
+                                            <li>
+                                              {`Location: ${potentialMatch.location.name}`}
+                                            </li>
+                                          )}
+                                        </ul>
+                                      </div>
+                                    </Label>
+                                    <Button
+                                      value={potentialMatch.id.toString()}
+                                      id={`match-${matchItem.item.id}-link-${potentialMatch.id}`}
+                                      onClick={() =>
+                                        updateMatchAcceptance(
+                                          matchState.sharedId,
+                                          false,
+                                        )
+                                      }
+                                    >
+                                      Same Match
+                                    </Button>
+                                  </div>
+                                ),
+                              )}
+                            </div>
+                          ) : (
+                            <p className="text-sm italic text-muted-foreground">
+                              No matches found on{" "}
+                              {new Date(
+                                matchItem.item.date,
+                              ).toLocaleDateString()}{" "}
+                              for the selected game
+                            </p>
+                          )}
+
+                          {gameMatches.length === 0 && (
+                            <p className="text-sm text-muted-foreground">
+                              This match will be added as a new match to your
+                              collection.
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="py-2 text-center text-sm text-muted-foreground">
+                          This match will not be added to your collection.
+                        </div>
+                      )}
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
+              );
+            })}
+        </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/apps/nextjs/src/app/dashboard/share-requests/[id]/_componenets/match-request.tsx
+++ b/apps/nextjs/src/app/dashboard/share-requests/[id]/_componenets/match-request.tsx
@@ -82,6 +82,7 @@ import {
 } from "@board-games/ui/tooltip";
 
 import { useTRPC } from "~/trpc/react";
+import ChildLocationsRequest from "./child-locations-request";
 import ChildPlayersRequest from "./child-players-request";
 
 type Match = Extract<
@@ -147,7 +148,13 @@ export default function MatchRequestPage({
   const [players, setPlayers] = useState<
     { sharedId: number; accept: boolean; linkedId: number | null }[]
   >([]);
+  const [locations, setLocations] = useState<
+    { sharedId: number; accept: boolean; linkedId: number | null }[]
+  >([]);
 
+  const childLocations = useMemo(() => {
+    return match.childItems.filter((item) => item.itemType === "location");
+  }, [match.childItems]);
   const childScoresheets = useMemo(() => {
     return match.childItems.filter((item) => item.itemType === "scoresheet");
   }, [match.childItems]);
@@ -256,6 +263,13 @@ export default function MatchRequestPage({
           accept: player.accept,
           linkedId: player.linkedId ?? undefined,
         })),
+        location: locations[0]
+          ? {
+              sharedId: locations[0].sharedId,
+              accept: locations[0].accept,
+              linkedId: locations[0].linkedId ?? undefined,
+            }
+          : undefined,
       });
     }
   };
@@ -468,6 +482,15 @@ export default function MatchRequestPage({
                 </AccordionItem>
               </Accordion>
             )}
+            {childLocations.length > 0 && (
+              <>
+                <ChildLocationsRequest
+                  childLocations={childLocations}
+                  locations={locations}
+                  setLocations={setLocations}
+                />
+              </>
+            )}
             {childPlayers.length > 0 && (
               <>
                 <ChildPlayersRequest
@@ -479,7 +502,11 @@ export default function MatchRequestPage({
             )}
           </CardContent>
           <CardFooter className="flex justify-between">
-            <Button variant="outline" type="button">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={() => router.push(`/dashboard/share-requests`)}
+            >
               Cancel
             </Button>
             <Button
@@ -760,7 +787,7 @@ export default function MatchRequestPage({
                                                         (fGame) => (
                                                           <CommandItem
                                                             key={fGame.id}
-                                                            value={fGame.name}
+                                                            value={fGame.id.toString()}
                                                             onSelect={() =>
                                                               handleGameSelect(
                                                                 fGame.id,

--- a/apps/nextjs/src/app/dashboard/share-requests/_components/share-requests.tsx
+++ b/apps/nextjs/src/app/dashboard/share-requests/_components/share-requests.tsx
@@ -364,6 +364,9 @@ export default function ShareRequestsPage() {
                               {request.players > 0 && (
                                 <li>{`${request.players} players`}</li>
                               )}
+                              {(request.locations ?? 0) > 0 && (
+                                <li>{`${request.locations} locations`}</li>
+                              )}
                             </ul>
                           </div>
                         )}
@@ -581,6 +584,9 @@ export default function ShareRequestsPage() {
                               )}
                               {request.players > 0 && (
                                 <li>{`${request.players} players`}</li>
+                              )}
+                              {(request.locations ?? 0) > 0 && (
+                                <li>{`${request.locations} locations`}</li>
                               )}
                             </ul>
                           </div>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean:workspaces": "turbo run clean",
     "db:push": "turbo -F @board-games/db push",
     "db:studio": "turbo -F @board-games/db studio",
+    "db:seed": "turbo -F @board-games/db seed",
     "dev": "turbo watch dev --continue",
     "dev:next": "turbo watch dev -F @board-games/nextjs...",
     "format": "turbo run format --continue -- --cache --cache-location .cache/.prettiercache",

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -163,11 +163,7 @@ export const gameRouter = createTRPCRouter({
               sharedWithId: ctx.userId,
             },
             with: {
-              match: {
-                with: {
-                  location: true,
-                },
-              },
+              match: true,
               sharedMatchPlayers: {
                 with: {
                   matchPlayer: true,
@@ -178,12 +174,20 @@ export const gameRouter = createTRPCRouter({
                   },
                 },
               },
+              sharedLocation: {
+                with: {
+                  location: true,
+                  linkedLocation: true,
+                },
+              },
             },
           },
         },
       });
       if (!result) return null;
       const linkedMatches = result.sharedGameMatches.map((mMatch) => {
+        const mSharedLocation = mMatch.sharedLocation;
+        const linkedLocation = mSharedLocation?.linkedLocation;
         return {
           type: "shared" as const,
           id: mMatch.id,
@@ -191,7 +195,14 @@ export const gameRouter = createTRPCRouter({
           date: mMatch.match.date,
           name: mMatch.match.name,
           finished: mMatch.match.finished,
-          location: mMatch.match.location?.name,
+          location: mSharedLocation
+            ? {
+                type: linkedLocation
+                  ? ("linked" as const)
+                  : ("shared" as const),
+                name: linkedLocation?.name ?? mSharedLocation.location.name,
+              }
+            : null,
           won:
             mMatch.sharedMatchPlayers.findIndex(
               (sharedMatchPlayer) =>
@@ -224,7 +235,10 @@ export const gameRouter = createTRPCRouter({
             date: Date;
             name: string;
             finished: boolean;
-            location: string | undefined;
+            location: {
+              type: "shared" | "linked" | "original";
+              name: string;
+            } | null;
             won: boolean;
             duration: number;
           }>((match) => {
@@ -239,7 +253,12 @@ export const gameRouter = createTRPCRouter({
                     player.winner && player.player.userId === ctx.userId,
                 ) !== -1,
               name: match.name,
-              location: match.location?.name,
+              location: match.location
+                ? {
+                    type: "original" as const,
+                    name: match.location.name,
+                  }
+                : null,
               finished: match.finished,
               duration: match.duration,
             };
@@ -522,8 +541,13 @@ export const gameRouter = createTRPCRouter({
             with: {
               match: {
                 with: {
-                  location: true,
                   scoresheet: true,
+                },
+              },
+              sharedLocation: {
+                with: {
+                  location: true,
+                  linkedLocation: true,
                 },
               },
               sharedMatchPlayers: {
@@ -558,7 +582,10 @@ export const gameRouter = createTRPCRouter({
         type: "original" | "shared";
         id: number;
         date: Date;
-        location: string | null;
+        location: {
+          type: "shared" | "linked" | "original";
+          name: string;
+        } | null;
         won: boolean;
         placement: number | null;
         score: number | null;
@@ -612,7 +639,12 @@ export const gameRouter = createTRPCRouter({
           type: "original" as const,
           id: match.id,
           date: match.date,
-          location: match.location?.name ?? null,
+          location: match.location
+            ? {
+                type: "original" as const,
+                name: match.location.name,
+              }
+            : null,
           won: match.finished ? (foundPlayer?.winner ?? false) : false,
           placement: match.finished ? (foundPlayer?.placement ?? null) : null,
           score: match.finished ? (foundPlayer?.score ?? null) : null,
@@ -656,13 +688,22 @@ export const gameRouter = createTRPCRouter({
         const foundSharedPlayer = returnedShareMatch.sharedMatchPlayers.find(
           (p) => p.sharedPlayer?.linkedPlayer?.userId === ctx.userId,
         )?.matchPlayer;
+        const mSharedLocation = returnedShareMatch.sharedLocation;
+        const mLinkedLocation = mSharedLocation?.linkedLocation;
         const mappedShareMatch = {
           type: "shared" as const,
           shareId: returnedShareMatch.id,
           id: returnedShareMatch.match.id,
           name: returnedShareMatch.match.name,
           date: returnedShareMatch.match.date,
-          location: returnedShareMatch.match.location?.name ?? null,
+          location: mSharedLocation
+            ? {
+                type: mLinkedLocation
+                  ? ("linked" as const)
+                  : ("shared" as const),
+                name: mLinkedLocation?.name ?? mSharedLocation.location.name,
+              }
+            : null,
           duration: returnedShareMatch.match.duration,
           finished: returnedShareMatch.match.finished,
           scoresheet: {
@@ -961,8 +1002,11 @@ export const gameRouter = createTRPCRouter({
           with: {
             match: {
               where: { finished: true },
+            },
+            sharedLocation: {
               with: {
                 location: true,
+                linkedLocation: true,
               },
             },
           },
@@ -991,8 +1035,11 @@ export const gameRouter = createTRPCRouter({
                 id: true,
                 date: true,
               },
+            },
+            sharedLocation: {
               with: {
                 location: true,
+                linkedLocation: true,
               },
             },
           },
@@ -1013,17 +1060,29 @@ export const gameRouter = createTRPCRouter({
       games: number;
       lastPlayed: {
         date: Date | null;
-        location: string | null;
+        location: {
+          type: "shared" | "linked" | "original";
+          name: string;
+        } | null;
       };
     }[] = gamesQuery.map((returnedGame) => {
       const firstOriginalMatch = returnedGame.matches[0];
       const linkedMatches = returnedGame.sharedGameMatches
         .map((mMatch) => {
           if (mMatch.match === null) return null;
+          const mSharedLocation = mMatch.sharedLocation;
+          const linkedLocation = mSharedLocation?.linkedLocation;
           return {
             id: mMatch.match.id,
             date: mMatch.match.date,
-            location: mMatch.match.location,
+            location: mSharedLocation
+              ? {
+                  type: linkedLocation
+                    ? ("linked" as const)
+                    : ("shared" as const),
+                  name: linkedLocation?.name ?? mSharedLocation.location.name,
+                }
+              : null,
           };
         })
         .filter((match) => match !== null);
@@ -1036,11 +1095,27 @@ export const gameRouter = createTRPCRouter({
         ) {
           return compareDesc(firstOriginalMatch.date, firstLinkedMatch.date) ===
             1
-            ? firstOriginalMatch
+            ? {
+                ...firstOriginalMatch,
+                location: firstOriginalMatch.location
+                  ? {
+                      type: "original" as const,
+                      name: firstOriginalMatch.location.name,
+                    }
+                  : null,
+              }
             : firstLinkedMatch;
         }
         if (firstOriginalMatch !== undefined) {
-          return firstOriginalMatch;
+          return {
+            ...firstOriginalMatch,
+            location: firstOriginalMatch.location
+              ? {
+                  type: "original" as const,
+                  name: firstOriginalMatch.location.name,
+                }
+              : null,
+          };
         }
         if (firstLinkedMatch !== undefined) {
           return firstLinkedMatch;
@@ -1067,18 +1142,34 @@ export const gameRouter = createTRPCRouter({
         games: linkedMatches.length + returnedGame.matches.length,
         lastPlayed: {
           date: firstMatch?.date ?? null,
-          location: firstMatch?.location?.name ?? null,
+          location: firstMatch?.location ?? null,
         },
       };
     });
     for (const returnedSharedGame of sharedGamesQuery) {
-      const returnedSharedMatches = returnedSharedGame.sharedMatches
+      const returnedSharedMatches: {
+        id: number;
+        date: Date;
+        location: {
+          type: "shared" | "linked" | "original";
+          name: string;
+        } | null;
+      }[] = returnedSharedGame.sharedMatches
         .map(
           (mMatch) =>
             mMatch.match !== null && {
               id: mMatch.match.id,
               date: mMatch.match.date,
-              location: mMatch.match.location,
+              location: mMatch.sharedLocation
+                ? {
+                    type: mMatch.sharedLocation.linkedLocation
+                      ? ("linked" as const)
+                      : ("shared" as const),
+                    name:
+                      mMatch.sharedLocation.linkedLocation?.name ??
+                      mMatch.sharedLocation.location.name,
+                  }
+                : null,
             },
         )
         .filter((match) => match !== false);
@@ -1103,7 +1194,7 @@ export const gameRouter = createTRPCRouter({
         games: returnedSharedMatches.length,
         lastPlayed: {
           date: firstMatch?.date ?? null,
-          location: firstMatch?.location?.name ?? null,
+          location: firstMatch?.location ?? null,
         },
       });
     }

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -467,21 +467,34 @@ export const gameRouter = createTRPCRouter({
           },
         },
       });
-      const mappedLinkedScoresheet = linkedGames.flatMap((linkedGame) => {
-        return linkedGame.sharedScoresheets.map((returnedSharedScoresheet) => {
-          return {
-            scoresheetType: "shared",
-            shareId: returnedSharedScoresheet.id,
-            ...returnedSharedScoresheet.scoresheet,
-            rounds: returnedSharedScoresheet.scoresheet?.rounds.map(
-              (round) => ({
-                ...round,
-                roundId: round.id,
-              }),
-            ),
-          };
-        });
-      });
+      const mappedLinkedScoresheet = linkedGames
+        .flatMap((linkedGame) => {
+          return linkedGame.sharedScoresheets.map(
+            (returnedSharedScoresheet) => {
+              if (!returnedSharedScoresheet.scoresheet) {
+                return null;
+              }
+              return {
+                scoresheetType: "shared" as const,
+                permission: returnedSharedScoresheet.permission,
+                shareId: returnedSharedScoresheet.id,
+                id: returnedSharedScoresheet.scoresheet.id,
+                name: returnedSharedScoresheet.scoresheet.name,
+                winCondition: returnedSharedScoresheet.scoresheet.winCondition,
+                isCoop: returnedSharedScoresheet.scoresheet.isCoop,
+                roundsScore: returnedSharedScoresheet.scoresheet.roundsScore,
+                targetScore: returnedSharedScoresheet.scoresheet.targetScore,
+                rounds: returnedSharedScoresheet.scoresheet.rounds.map(
+                  (round) => ({
+                    ...round,
+                    roundId: round.id,
+                  }),
+                ),
+              };
+            },
+          );
+        })
+        .filter((scoresheet) => scoresheet !== null);
       return {
         game: {
           id: result.id,
@@ -496,8 +509,13 @@ export const gameRouter = createTRPCRouter({
         },
         scoresheets: [
           ...result.scoresheets.map((scoresheet) => ({
-            scoresheetType: "original",
-            ...scoresheet,
+            scoresheetType: "original" as const,
+            id: scoresheet.id,
+            name: scoresheet.name,
+            winCondition: scoresheet.winCondition,
+            isCoop: scoresheet.isCoop,
+            roundsScore: scoresheet.roundsScore,
+            targetScore: scoresheet.targetScore,
             rounds: scoresheet.rounds.map((round) => ({
               ...round,
               roundId: round.id,

--- a/packages/api/src/routers/match.ts
+++ b/packages/api/src/routers/match.ts
@@ -756,48 +756,6 @@ export const matchRouter = createTRPCRouter({
         gameId: match.game.id,
       }));
     }),
-  getMatchesByLocation: protectedUserProcedure
-    .input(z.object({ locationId: z.number() }))
-    .query(async ({ ctx, input }) => {
-      const matches = await ctx.db.query.match.findMany({
-        where: {
-          userId: ctx.userId,
-          locationId: input.locationId,
-        },
-        with: {
-          game: {
-            with: {
-              image: true,
-            },
-          },
-          matchPlayers: {
-            with: {
-              player: true,
-            },
-          },
-          location: true,
-        },
-      });
-      return matches.map((match) => ({
-        id: match.id,
-        date: match.date,
-        name: match.name,
-        finished: match.finished,
-        won:
-          match.matchPlayers.findIndex(
-            (player) => player.winner && player.player.userId === ctx.userId,
-          ) !== -1,
-        players: match.matchPlayers.map((matchPlayer) => {
-          return {
-            id: matchPlayer.player.id,
-            name: matchPlayer.player.name,
-          };
-        }),
-        gameImageUrl: match.game.image?.url,
-        gameName: match.game.name,
-        gameId: match.game.id,
-      }));
-    }),
   deleteMatch: protectedUserProcedure
     .input(selectMatchSchema.pick({ id: true }))
     .mutation(async ({ ctx, input }) => {

--- a/packages/api/src/routers/sharing/index.ts
+++ b/packages/api/src/routers/sharing/index.ts
@@ -3,6 +3,7 @@ import { shareAcceptanceRouter } from "./share-accept";
 import { shareGameRouter } from "./share-game";
 import { shareLinkRouter } from "./share-link";
 import { shareLinkingRouter } from "./share-linking";
+import { shareLocationRouter } from "./share-location";
 import { shareMatchRouter } from "./share-match";
 import { shareMetaRouter } from "./share-meta";
 import { shareRequestRouter } from "./share-request";
@@ -14,5 +15,6 @@ export const sharingRouter = mergeRouters(
   shareMetaRouter,
   shareRequestRouter,
   shareGameRouter,
+  shareLocationRouter,
   shareMatchRouter,
 );

--- a/packages/api/src/routers/sharing/share-accept.ts
+++ b/packages/api/src/routers/sharing/share-accept.ts
@@ -2,9 +2,11 @@ import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
+import type { selectSharedLocationSchema } from "@board-games/db/zodSchema";
 import {
   game,
   sharedGame,
+  sharedLocation,
   sharedMatch,
   sharedMatchPlayer,
   sharedPlayer,
@@ -201,6 +203,34 @@ export const shareAcceptanceRouter = createTRPCRouter({
               },
             });
             if (!sharedMatchExists) {
+              let sharedLocationForMatch: z.infer<
+                typeof selectSharedLocationSchema
+              > | null = null;
+              if (returnedMatch.locationId !== null) {
+                const existingSharedLocation =
+                  await tx.query.sharedLocation.findFirst({
+                    where: {
+                      ownerId: returnedMatchRequest.ownerId,
+                      sharedWithId: ctx.userId,
+                      locationId: returnedMatch.locationId,
+                    },
+                  });
+                if (!existingSharedLocation) {
+                  const [insertedSharedLocation] = await tx
+                    .insert(sharedLocation)
+                    .values({
+                      ownerId: returnedMatchRequest.ownerId,
+                      sharedWithId: ctx.userId,
+                      locationId: returnedMatch.locationId,
+                      permission: returnedMatchRequest.permission,
+                    })
+                    .returning();
+                  if (!insertedSharedLocation) {
+                    throw Error("Shared Location not found");
+                  }
+                  sharedLocationForMatch = insertedSharedLocation;
+                }
+              }
               const [returnedSharedMatch] = await tx
                 .insert(sharedMatch)
                 .values({
@@ -208,6 +238,7 @@ export const shareAcceptanceRouter = createTRPCRouter({
                   sharedWithId: ctx.userId,
                   matchId: returnedMatchRequest.itemId,
                   sharedGameId: sharedGameExists.id,
+                  sharedLocationId: sharedLocationForMatch?.id ?? null,
                   permission: returnedMatchRequest.permission,
                 })
                 .returning();
@@ -494,6 +525,34 @@ export const shareAcceptanceRouter = createTRPCRouter({
             },
           });
           if (!existingSharedMatch) {
+            let sharedLocationForMatch: z.infer<
+              typeof selectSharedLocationSchema
+            > | null = null;
+            if (returnedMatch.locationId !== null) {
+              const existingSharedLocation =
+                await tx.query.sharedLocation.findFirst({
+                  where: {
+                    ownerId: existingRequest.ownerId,
+                    sharedWithId: ctx.userId,
+                    locationId: returnedMatch.locationId,
+                  },
+                });
+              if (!existingSharedLocation) {
+                const [insertedSharedLocation] = await tx
+                  .insert(sharedLocation)
+                  .values({
+                    ownerId: existingRequest.ownerId,
+                    sharedWithId: ctx.userId,
+                    locationId: returnedMatch.locationId,
+                    permission: existingRequest.permission,
+                  })
+                  .returning();
+                if (!insertedSharedLocation) {
+                  throw Error("Shared Location not found");
+                }
+                sharedLocationForMatch = insertedSharedLocation;
+              }
+            }
             const [returnedSharedMatch] = await tx
               .insert(sharedMatch)
               .values({
@@ -501,6 +560,7 @@ export const shareAcceptanceRouter = createTRPCRouter({
                 sharedWithId: ctx.userId,
                 matchId: existingRequest.itemId,
                 sharedGameId: sharedGameExists.id,
+                sharedLocationId: sharedLocationForMatch?.id ?? null,
                 permission: existingRequest.permission,
               })
               .returning();
@@ -612,6 +672,34 @@ export const shareAcceptanceRouter = createTRPCRouter({
             },
           });
           if (!existingSharedMatch) {
+            let sharedLocationForMatch: z.infer<
+              typeof selectSharedLocationSchema
+            > | null = null;
+            if (returnedMatch.locationId !== null) {
+              const existingSharedLocation =
+                await tx.query.sharedLocation.findFirst({
+                  where: {
+                    ownerId: existingRequest.ownerId,
+                    sharedWithId: ctx.userId,
+                    locationId: returnedMatch.locationId,
+                  },
+                });
+              if (!existingSharedLocation) {
+                const [insertedSharedLocation] = await tx
+                  .insert(sharedLocation)
+                  .values({
+                    ownerId: existingRequest.ownerId,
+                    sharedWithId: ctx.userId,
+                    locationId: returnedMatch.locationId,
+                    permission: existingRequest.permission,
+                  })
+                  .returning();
+                if (!insertedSharedLocation) {
+                  throw Error("Shared Location not found");
+                }
+                sharedLocationForMatch = insertedSharedLocation;
+              }
+            }
             const [returnedSharedMatch] = await tx
               .insert(sharedMatch)
               .values({
@@ -619,6 +707,7 @@ export const shareAcceptanceRouter = createTRPCRouter({
                 sharedWithId: ctx.userId,
                 matchId: existingRequest.itemId,
                 sharedGameId: returnedSharedGame.id,
+                sharedLocationId: sharedLocationForMatch?.id ?? null,
                 permission: existingRequest.permission,
               })
               .returning();
@@ -1079,6 +1168,34 @@ export const shareAcceptanceRouter = createTRPCRouter({
                     },
                   );
                   if (!shareMatchExists) {
+                    let sharedLocationForMatch: z.infer<
+                      typeof selectSharedLocationSchema
+                    > | null = null;
+                    if (returnedMatch.locationId !== null) {
+                      const existingSharedLocation =
+                        await tx.query.sharedLocation.findFirst({
+                          where: {
+                            ownerId: existingRequest.ownerId,
+                            sharedWithId: ctx.userId,
+                            locationId: returnedMatch.locationId,
+                          },
+                        });
+                      if (!existingSharedLocation) {
+                        const [insertedSharedLocation] = await tx
+                          .insert(sharedLocation)
+                          .values({
+                            ownerId: existingRequest.ownerId,
+                            sharedWithId: ctx.userId,
+                            locationId: returnedMatch.locationId,
+                            permission: matchShareRequest.permission,
+                          })
+                          .returning();
+                        if (!insertedSharedLocation) {
+                          throw Error("Shared Location not found");
+                        }
+                        sharedLocationForMatch = insertedSharedLocation;
+                      }
+                    }
                     const [returnedSharedMatch] = await tx
                       .insert(sharedMatch)
                       .values({
@@ -1086,6 +1203,7 @@ export const shareAcceptanceRouter = createTRPCRouter({
                         sharedWithId: ctx.userId,
                         matchId: returnedMatch.id,
                         sharedGameId: shareGameExists.id,
+                        sharedLocationId: sharedLocationForMatch?.id ?? null,
                         permission: matchShareRequest.permission,
                       })
                       .returning();
@@ -1242,6 +1360,34 @@ export const shareAcceptanceRouter = createTRPCRouter({
                     },
                   );
                   if (!shareMatchExists) {
+                    let sharedLocationForMatch: z.infer<
+                      typeof selectSharedLocationSchema
+                    > | null = null;
+                    if (returnedMatch.locationId !== null) {
+                      const existingSharedLocation =
+                        await tx.query.sharedLocation.findFirst({
+                          where: {
+                            ownerId: existingRequest.ownerId,
+                            sharedWithId: ctx.userId,
+                            locationId: returnedMatch.locationId,
+                          },
+                        });
+                      if (!existingSharedLocation) {
+                        const [insertedSharedLocation] = await tx
+                          .insert(sharedLocation)
+                          .values({
+                            ownerId: existingRequest.ownerId,
+                            sharedWithId: ctx.userId,
+                            locationId: returnedMatch.locationId,
+                            permission: matchShareRequest.permission,
+                          })
+                          .returning();
+                        if (!insertedSharedLocation) {
+                          throw Error("Shared Location not found");
+                        }
+                        sharedLocationForMatch = insertedSharedLocation;
+                      }
+                    }
                     const [returnedSharedMatch] = await tx
                       .insert(sharedMatch)
                       .values({
@@ -1249,6 +1395,7 @@ export const shareAcceptanceRouter = createTRPCRouter({
                         sharedWithId: ctx.userId,
                         matchId: returnedMatch.id,
                         sharedGameId: returnedSharedGame.id,
+                        sharedLocationId: sharedLocationForMatch?.id ?? null,
                         permission: matchShareRequest.permission,
                       })
                       .returning();

--- a/packages/api/src/routers/sharing/share-game.ts
+++ b/packages/api/src/routers/sharing/share-game.ts
@@ -27,9 +27,11 @@ export const shareGameRouter = createTRPCRouter({
               sharedWithId: ctx.userId,
             },
             with: {
-              match: {
+              match: true,
+              sharedLocation: {
                 with: {
                   location: true,
+                  linkedLocation: true,
                 },
               },
               sharedMatchPlayers: {
@@ -86,7 +88,16 @@ export const shareGameRouter = createTRPCRouter({
           id: mMatch.id,
           gameId: returnedGame.id,
           date: mMatch.match.date,
-          location: mMatch.match.location?.name,
+          location: mMatch.sharedLocation
+            ? {
+                type: mMatch.sharedLocation.linkedLocation
+                  ? ("linked" as const)
+                  : ("shared" as const),
+                name:
+                  mMatch.sharedLocation.linkedLocation?.name ??
+                  mMatch.sharedLocation.location.name,
+              }
+            : null,
           finished: mMatch.match.finished,
           name: mMatch.match.name,
           duration: mMatch.match.duration,

--- a/packages/api/src/routers/sharing/share-location.ts
+++ b/packages/api/src/routers/sharing/share-location.ts
@@ -1,0 +1,137 @@
+import { selectSharedLocationSchema } from "@board-games/db/zodSchema";
+
+import { createTRPCRouter, protectedUserProcedure } from "../../trpc";
+
+export const shareLocationRouter = createTRPCRouter({
+  getSharedLocation: protectedUserProcedure
+    .input(selectSharedLocationSchema.pick({ id: true }))
+    .query(async ({ ctx, input }) => {
+      const returnedLocation = await ctx.db.query.sharedLocation.findFirst({
+        where: {
+          id: input.id,
+          sharedWithId: ctx.userId,
+        },
+        with: {
+          location: true,
+          sharedMatches: {
+            where: {
+              sharedWithId: ctx.userId,
+            },
+            with: {
+              match: true,
+              sharedGame: {
+                with: {
+                  linkedGame: {
+                    with: {
+                      image: true,
+                    },
+                  },
+                  game: {
+                    with: {
+                      image: true,
+                    },
+                  },
+                },
+              },
+              sharedMatchPlayers: {
+                with: {
+                  matchPlayer: true,
+                  sharedPlayer: {
+                    with: {
+                      linkedPlayer: true,
+
+                      player: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      if (!returnedLocation) {
+        return null;
+      }
+      const locationMatches: {
+        type: "shared";
+        id: number;
+        gameId: number;
+        date: Date;
+        name: string;
+        finished: boolean;
+        won: boolean;
+        players: {
+          id: number;
+          name: string;
+        }[];
+        gameImageUrl: string | undefined;
+        gameName: string | undefined;
+      }[] = returnedLocation.sharedMatches.map((m) => {
+        const linkedGame = m.sharedGame.linkedGame;
+        const mPlayers = m.sharedMatchPlayers
+          .map((sharedMatchPlayer) => {
+            if (sharedMatchPlayer.sharedPlayer === null) {
+              return null;
+            }
+            if (sharedMatchPlayer.sharedPlayer.linkedPlayer === null) {
+              return {
+                type: "shared" as const,
+                isUser: false,
+                id: sharedMatchPlayer.sharedPlayer.id,
+                name: sharedMatchPlayer.sharedPlayer.player.name,
+                placement: sharedMatchPlayer.matchPlayer.placement,
+                winner: sharedMatchPlayer.matchPlayer.winner,
+              };
+            }
+            return {
+              type: "original" as const,
+              isUser:
+                sharedMatchPlayer.sharedPlayer.linkedPlayer.userId ===
+                ctx.userId,
+
+              id: sharedMatchPlayer.sharedPlayer.linkedPlayer.id,
+              name: sharedMatchPlayer.sharedPlayer.linkedPlayer.name,
+              placement: sharedMatchPlayer.matchPlayer.placement,
+              winner: sharedMatchPlayer.matchPlayer.winner,
+            };
+          })
+          .filter((p) => p !== null);
+        if (linkedGame) {
+          return {
+            type: "shared" as const,
+            id: m.id,
+            gameId: m.sharedGame.id,
+            date: m.match.date,
+            name: m.match.name,
+            finished: m.match.finished,
+            won:
+              mPlayers.findIndex((player) => player.winner && player.isUser) !==
+              -1,
+            players: mPlayers,
+            gameImageUrl: linkedGame.image?.url,
+            gameName: linkedGame.name,
+          };
+        }
+        return {
+          type: "shared" as const,
+          id: m.id,
+          gameId: m.sharedGame.id,
+          date: m.match.date,
+          name: m.match.name,
+          finished: m.match.finished,
+          won:
+            mPlayers.findIndex((player) => player.winner && player.isUser) !==
+            -1,
+          players: mPlayers,
+          gameImageUrl: m.sharedGame.game.image?.url,
+          gameName: m.sharedGame.game.name,
+        };
+      });
+      return {
+        id: returnedLocation.id,
+        name: returnedLocation.location.name,
+        isDefault: returnedLocation.isDefault,
+        matches: locationMatches,
+      };
+    }),
+});

--- a/packages/api/src/routers/sharing/share-match.ts
+++ b/packages/api/src/routers/sharing/share-match.ts
@@ -191,11 +191,7 @@ export const shareMatchRouter = createTRPCRouter({
                   sharedWithId: ctx.userId,
                 },
                 with: {
-                  match: {
-                    with: {
-                      location: true,
-                    },
-                  },
+                  match: {},
                   sharedMatchPlayers: {
                     with: {
                       matchPlayer: {
@@ -218,13 +214,18 @@ export const shareMatchRouter = createTRPCRouter({
                       },
                     },
                   },
+                  sharedLocation: {
+                    with: {
+                      location: true,
+                      linkedLocation: true,
+                    },
+                  },
                 },
               },
             },
           },
           match: {
             with: {
-              location: true,
               scoresheet: true,
               teams: true,
             },
@@ -258,6 +259,12 @@ export const shareMatchRouter = createTRPCRouter({
               },
             },
           },
+          sharedLocation: {
+            with: {
+              location: true,
+              linkedLocation: true,
+            },
+          },
         },
       });
       if (!returnedSharedMatch) {
@@ -271,7 +278,10 @@ export const shareMatchRouter = createTRPCRouter({
         name: string;
         finished: boolean;
         createdAt: Date;
-        locationName: string | null;
+        location: {
+          type: "shared" | "linked" | "original";
+          name: string;
+        } | null;
         matchPlayers: {
           id: number;
           type: "original" | "shared";
@@ -290,7 +300,16 @@ export const shareMatchRouter = createTRPCRouter({
         name: sharedMatch.match.name,
         finished: sharedMatch.match.finished,
         createdAt: sharedMatch.match.createdAt,
-        locationName: sharedMatch.match.location?.name ?? null,
+        location: sharedMatch.sharedLocation
+          ? {
+              type: sharedMatch.sharedLocation.linkedLocation
+                ? ("linked" as const)
+                : ("shared" as const),
+              name:
+                sharedMatch.sharedLocation.linkedLocation?.name ??
+                sharedMatch.sharedLocation.location.name,
+            }
+          : null,
         matchPlayers: sharedMatch.sharedMatchPlayers
           .map((sharedMatchPlayer) => {
             const sharedPlayer = sharedMatchPlayer.sharedPlayer;
@@ -332,7 +351,9 @@ export const shareMatchRouter = createTRPCRouter({
             name: returnedMatch.name,
             finished: returnedMatch.finished,
             createdAt: returnedMatch.createdAt,
-            locationName: returnedMatch.location?.name ?? null,
+            location: returnedMatch.location
+              ? { type: "original", name: returnedMatch.location.name }
+              : null,
             matchPlayers: returnedMatch.matchPlayers.map((matchPlayer) => ({
               type: "original" as const,
               id: matchPlayer.id,
@@ -516,7 +537,16 @@ export const shareMatchRouter = createTRPCRouter({
         date: returnedSharedMatch.match.date,
         name: returnedSharedMatch.match.name,
         scoresheet: returnedSharedMatch.match.scoresheet,
-        locationName: returnedSharedMatch.match.location?.name,
+        location: returnedSharedMatch.sharedLocation
+          ? {
+              type: returnedSharedMatch.sharedLocation.linkedLocation
+                ? ("linked" as const)
+                : ("shared" as const),
+              name:
+                returnedSharedMatch.sharedLocation.linkedLocation?.name ??
+                returnedSharedMatch.sharedLocation.location.name,
+            }
+          : null,
         comment: returnedSharedMatch.match.comment,
         gameType: returnedSharedMatch.sharedGame.linkedGame
           ? "linked"

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -414,7 +414,6 @@ export const relations = defineRelations(schema, (r) => ({
     sharedLocation: r.one.sharedLocation({
       from: r.sharedMatch.sharedLocationId,
       to: r.sharedLocation.id,
-      optional: false,
     }),
     sharedLocationPassthrough: r.one.location({
       from: r.sharedMatch.sharedLocationId.through(r.sharedLocation.id),

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -95,6 +95,11 @@ export const relations = defineRelations(schema, (r) => ({
     locations: r.many.location({
       from: r.user.id,
       to: r.location.createdBy,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     linkedPlayers: r.many.player({
       from: r.user.id,
@@ -300,6 +305,11 @@ export const relations = defineRelations(schema, (r) => ({
     linkedLocation: r.one.location({
       from: r.sharedLocation.linkedLocationId,
       to: r.location.id,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     sharedMatches: r.many.sharedMatch({
       from: r.sharedLocation.id,
@@ -419,11 +429,6 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.sharedMatch.sharedLocationId,
       to: r.sharedLocation.id,
     }),
-    sharedLocationPassthrough: r.one.location({
-      from: r.sharedMatch.sharedLocationId.through(r.sharedLocation.id),
-      to: r.location.id.through(r.sharedLocation.locationId),
-      optional: false,
-    }),
   },
   match: {
     createdBy: r.one.user({
@@ -438,6 +443,11 @@ export const relations = defineRelations(schema, (r) => ({
     location: r.one.location({
       from: r.match.locationId,
       to: r.location.id,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     scoresheet: r.one.scoresheet({
       from: r.match.scoresheetId,

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -276,6 +276,10 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.location.id,
       to: r.sharedLocation.linkedLocationId,
     }),
+    sharedMatches: r.many.sharedMatch({
+      from: r.location.id.through(r.sharedLocation.linkedLocationId),
+      to: r.sharedMatch.sharedLocationId.through(r.sharedLocation.id),
+    }),
   },
   sharedLocation: {
     owner: r.one.user({

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -164,6 +164,14 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.user.id,
       to: r.sharedMatchPlayer.sharedWithId,
     }),
+    sharedLocationsOwner: r.many.sharedLocation({
+      from: r.user.id,
+      to: r.sharedLocation.ownerId,
+    }),
+    sharedLocationsSharedWith: r.many.sharedLocation({
+      from: r.user.id,
+      to: r.sharedLocation.sharedWithId,
+    }),
     shareRequestsReceived: r.many.shareRequest({
       from: r.user.id,
       to: r.shareRequest.sharedWithId,
@@ -263,6 +271,35 @@ export const relations = defineRelations(schema, (r) => ({
     matches: r.many.match({
       from: r.location.id,
       to: r.match.locationId,
+    }),
+    linkedLocations: r.many.sharedLocation({
+      from: r.location.id,
+      to: r.sharedLocation.linkedLocationId,
+    }),
+  },
+  sharedLocation: {
+    owner: r.one.user({
+      from: r.sharedLocation.ownerId,
+      to: r.user.id,
+      optional: false,
+    }),
+    sharedWith: r.one.user({
+      from: r.sharedLocation.sharedWithId,
+      to: r.user.id,
+      optional: false,
+    }),
+    location: r.one.location({
+      from: r.sharedLocation.locationId,
+      to: r.location.id,
+      optional: false,
+    }),
+    linkedLocation: r.one.location({
+      from: r.sharedLocation.linkedLocationId,
+      to: r.location.id,
+    }),
+    sharedMatches: r.many.sharedMatch({
+      from: r.sharedLocation.id,
+      to: r.sharedMatch.sharedLocationId,
     }),
   },
   player: {
@@ -373,6 +410,16 @@ export const relations = defineRelations(schema, (r) => ({
     sharedMatchPlayers: r.many.sharedMatchPlayer({
       from: r.sharedMatch.id,
       to: r.sharedMatchPlayer.sharedMatchId,
+    }),
+    sharedLocation: r.one.sharedLocation({
+      from: r.sharedMatch.sharedLocationId,
+      to: r.sharedLocation.id,
+      optional: false,
+    }),
+    sharedLocationPassthrough: r.one.location({
+      from: r.sharedMatch.sharedLocationId.through(r.sharedLocation.id),
+      to: r.location.id.through(r.sharedLocation.locationId),
+      optional: false,
     }),
   },
   match: {

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -20,3 +20,4 @@ export { default as sharedPlayer } from "./sharedPlayer";
 export { default as shareRequest } from "./shareRequest";
 export { default as sharedScoresheet } from "./sharedScoresheet";
 export { default as sharedMatchPlayer } from "./sharedMatchPlayer";
+export { default as sharedLocation } from "./sharedLocation";

--- a/packages/db/src/schema/location.ts
+++ b/packages/db/src/schema/location.ts
@@ -26,6 +26,7 @@ const locations = createTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
       () => new Date(),
     ),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [index("boardgames_location_name_index").on(table.name)],
 );

--- a/packages/db/src/schema/shareRequest.ts
+++ b/packages/db/src/schema/shareRequest.ts
@@ -25,7 +25,14 @@ const shareRequest = createTable(
       .unique()
       .notNull(),
     itemType: text("item_type", {
-      enum: ["game", "match", "player", "scoresheet"],
+      enum: [
+        "game",
+        "match",
+        "player",
+        "scoresheet",
+        "location",
+        "matchPlayer",
+      ],
     }).notNull(),
     itemId: integer("item_id").notNull(),
     permission: text("permission", { enum: ["view", "edit"] })

--- a/packages/db/src/schema/sharedLocation.ts
+++ b/packages/db/src/schema/sharedLocation.ts
@@ -1,5 +1,12 @@
 import { sql } from "drizzle-orm";
-import { index, integer, serial, text, timestamp } from "drizzle-orm/pg-core";
+import {
+  boolean,
+  index,
+  integer,
+  serial,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
 
 import { createTable } from "./baseTable";
 import location from "./location";
@@ -21,6 +28,7 @@ const sharedLocation = createTable(
     linkedLocationId: integer("linked_location_id").references(
       () => location.id,
     ),
+    isDefault: boolean("is_default").default(false).notNull(),
     permission: text("permission", { enum: ["view", "edit"] })
       .default("view")
       .notNull(),

--- a/packages/db/src/schema/sharedLocation.ts
+++ b/packages/db/src/schema/sharedLocation.ts
@@ -1,0 +1,43 @@
+import { sql } from "drizzle-orm";
+import { index, integer, serial, text, timestamp } from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import location from "./location";
+import user from "./user";
+
+const sharedLocation = createTable(
+  "shared_location",
+  {
+    id: serial("id").primaryKey(),
+    ownerId: integer("owner_id")
+      .references(() => user.id)
+      .notNull(),
+    sharedWithId: integer("shared_with_id")
+      .references(() => user.id)
+      .notNull(),
+    locationId: integer("location_id")
+      .references(() => location.id)
+      .notNull(),
+    linkedLocationId: integer("linked_location_id").references(
+      () => location.id,
+    ),
+    permission: text("permission", { enum: ["view", "edit"] })
+      .default("view")
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .default(sql`CURRENT_TIMESTAMP`)
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+      () => new Date(),
+    ),
+  },
+  (table) => [
+    index("boardgames_shared_location_owner_id_index").on(table.ownerId),
+    index("boardgames_shared_location_shared_with_id_index").on(
+      table.sharedWithId,
+    ),
+    index("boardgames_shared_location_location_id_index").on(table.locationId),
+    index("boardgames_shared_location_id_index").on(table.id),
+  ],
+);
+export default sharedLocation;

--- a/packages/db/src/schema/sharedMatch.ts
+++ b/packages/db/src/schema/sharedMatch.ts
@@ -5,6 +5,7 @@ import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { createTable } from "./baseTable";
 import match from "./match";
 import sharedGame from "./sharedGame";
+import sharedLocation from "./sharedLocation";
 import user from "./user";
 
 const sharedMatch = createTable(
@@ -23,6 +24,9 @@ const sharedMatch = createTable(
     sharedGameId: integer("shared_game_id")
       .references(() => sharedGame.id)
       .notNull(),
+    sharedLocationId: integer("shared_location_id").references(
+      () => sharedLocation.id,
+    ),
     permission: text("permission", { enum: ["view", "edit"] })
       .default("view")
       .notNull(),

--- a/packages/db/src/zodSchema/index.ts
+++ b/packages/db/src/zodSchema/index.ts
@@ -15,6 +15,7 @@ import {
   roundPlayer,
   scoresheet,
   sharedGame,
+  sharedLocation,
   sharedMatch,
   sharedMatchPlayer,
   sharedPlayer,
@@ -99,3 +100,6 @@ export const insertSharedMatchPlayerSchema =
 
 export const selectSharedMatchPlayerSchema =
   createSelectSchema(sharedMatchPlayer);
+
+export const insertSharedLocationSchema = createInsertSchema(sharedLocation);
+export const selectSharedLocationSchema = createSelectSchema(sharedLocation);

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,10 @@
       "cache": false,
       "persistent": true
     },
+    "seed": {
+      "cache": false,
+      "persistent": false
+    },
     "ui-add": {
       "cache": false,
       "interactive": true


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Change log
- Implement shared location page with match listing and loading states  
- Enhance location deletion, drop-down functionality, and soft-delete support  
- Improve location retrieval and match display logic to handle null/shared data  
- Refactor location UI components for default editing, permissions, and conditional actions  
- Add child-locations request component for game/match sharing flows  
- Extend share-accept logic to handle shared locations alongside matches  
- Simplify share component friend selection and share-requests display  
- Update database seeding to generate games, locations, and players with Faker for testing  
