### PR TITLE
feat(database): implement soft deletion across various entities

### DIFF
--- a/apps/nextjs/src/app/dashboard/calendar/_components/calendar-day.tsx
+++ b/apps/nextjs/src/app/dashboard/calendar/_components/calendar-day.tsx
@@ -1,44 +1,41 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 import { cn } from "@board-games/ui/utils";
 
 interface CalendarDayProps {
   day: Date;
-  matchIds: number[];
+  matches: { matches: number[]; date: Date } | undefined;
 }
 
-export function CalendarDay({ day, matchIds }: CalendarDayProps) {
-  const router = useRouter();
-  const hasMatches = matchIds.length > 0;
+export function CalendarDay({ day, matches }: CalendarDayProps) {
+  const hasMatches = matches && matches.matches.length > 0;
 
-  const handleClick = () => {
-    if (hasMatches) {
-      router.push(`/dashboard/calendar/${day.toISOString().split("T")[0]}`);
-    }
-  };
-
+  if (hasMatches) {
+    return (
+      <Link
+        href={`/dashboard/calendar/${matches.date.toString().split(" ")[0]}`}
+        className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg bg-secondary text-sm font-normal text-secondary-foreground hover:bg-secondary/80 aria-selected:opacity-100 sm:h-12 sm:w-12 sm:text-lg md:h-16 md:w-16 lg:h-20 lg:w-20"
+      >
+        <span>{day.getDate()}</span>
+        <span
+          className="absolute bottom-0 right-0 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground"
+          aria-label={`${matches.matches.length} match${matches.matches.length !== 1 ? "es" : ""}`}
+        >
+          {matches.matches.length}
+        </span>
+      </Link>
+    );
+  }
   return (
     <div
-      onClick={handleClick}
       className={cn(
         "h-9 w-9 font-normal aria-selected:opacity-100 sm:h-12 sm:w-12 md:h-16 md:w-16 lg:h-20 lg:w-20",
-        hasMatches
-          ? "cursor-pointer bg-secondary text-secondary-foreground hover:bg-secondary/80"
-          : "",
         "flex items-center justify-center rounded-lg text-sm sm:text-lg",
       )}
     >
       <span>{day.getDate()}</span>
-      {hasMatches && (
-        <span
-          className="absolute bottom-0 right-0 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground"
-          aria-label={`${matchIds.length} match${matchIds.length !== 1 ? "es" : ""}`}
-        >
-          {matchIds.length}
-        </span>
-      )}
     </div>
   );
 }

--- a/apps/nextjs/src/app/dashboard/calendar/_components/client-calendar.tsx
+++ b/apps/nextjs/src/app/dashboard/calendar/_components/client-calendar.tsx
@@ -8,7 +8,7 @@ import { Calendar } from "@board-games/ui/calendar";
 import { CalendarDay } from "./calendar-day";
 
 interface ClientCalendarProps {
-  matchDayMap: Map<string, number[]>;
+  matchDayMap: Map<string, { matches: number[]; date: Date }>;
 }
 
 export function ClientCalendar({ matchDayMap }: ClientCalendarProps) {
@@ -26,7 +26,7 @@ export function ClientCalendar({ matchDayMap }: ClientCalendarProps) {
         date.getMonth() === selectedMonthNum &&
         date.getFullYear() === selectedYear
       ) {
-        totalGames += ids.length;
+        totalGames += ids.matches.length;
       }
     });
 
@@ -70,7 +70,7 @@ export function ClientCalendar({ matchDayMap }: ClientCalendarProps) {
               return (
                 <CalendarDay
                   day={date}
-                  matchIds={matchDayMap.get(format(date, "MM-dd-yy")) ?? []}
+                  matches={matchDayMap.get(format(date, "MM-dd-yy"))}
                   {...props}
                 />
               );

--- a/apps/nextjs/src/app/dashboard/calendar/page.tsx
+++ b/apps/nextjs/src/app/dashboard/calendar/page.tsx
@@ -8,7 +8,10 @@ import { ClientCalendar } from "./_components/client-calendar";
 export default async function Page() {
   const dates = await caller.match.getMatchesByCalender();
   const matchDayMap = new Map(
-    dates.map((md) => [format(md.date, "MM-dd-yy"), md.ids]),
+    dates.map((md) => [
+      format(md.date, "MM-dd-yy"),
+      { matches: md.ids, date: md.date },
+    ]),
   );
   //TODO add shared matches
   return (

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -1473,7 +1473,7 @@ export const gameRouter = createTRPCRouter({
         const updatedMatches = await tx
           .update(match)
           .set({ deletedAt: new Date() })
-          .where(and(eq(match.gameId, input.id), eq(game.userId, ctx.userId)))
+          .where(and(eq(match.gameId, input.id), eq(match.userId, ctx.userId)))
           .returning();
         await tx
           .update(matchPlayer)

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -1,7 +1,7 @@
 import type { SQL } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { compareDesc } from "date-fns";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
 import type {
@@ -21,6 +21,7 @@ import {
   round,
   roundPlayer,
   scoresheet,
+  sharedGame,
 } from "@board-games/db/schema";
 import {
   insertGameSchema,
@@ -137,7 +138,9 @@ export const gameRouter = createTRPCRouter({
         where: {
           id: input.id,
           userId: ctx.userId,
-          deleted: false,
+          deletedAt: {
+            isNull: true,
+          },
         },
         with: {
           image: {
@@ -270,14 +273,12 @@ export const gameRouter = createTRPCRouter({
   getGameMetaData: protectedUserProcedure
     .input(selectGameSchema.pick({ id: true }))
     .query(async ({ ctx, input }) => {
-      const result = (
-        await ctx.db
-          .select({ id: game.id, name: game.name, image: image.url })
-          .from(game)
-          .where(eq(game.id, input.id))
-          .leftJoin(image, eq(game.imageId, image.id))
-          .limit(1)
-      )[0];
+      const [result] = await ctx.db
+        .select({ id: game.id, name: game.name, image: image.url })
+        .from(game)
+        .where(and(eq(game.id, input.id), isNull(game.deletedAt)))
+        .leftJoin(image, eq(game.imageId, image.id))
+        .limit(1);
       if (!result) return null;
       return {
         id: result.id,
@@ -300,6 +301,9 @@ export const gameRouter = createTRPCRouter({
               type: "Game",
             },
           ],
+          deletedAt: {
+            isNull: true,
+          },
         },
       });
       const linkedGames = await ctx.db.query.sharedGame.findMany({
@@ -348,7 +352,6 @@ export const gameRouter = createTRPCRouter({
           );
         })
         .filter((scoresheet) => scoresheet !== null);
-      //TODO add Shared scoresheets for now
       const mappedScoresheets: {
         scoresheetType: "shared" | "original";
         id: number;
@@ -384,7 +387,9 @@ export const gameRouter = createTRPCRouter({
         where: {
           id: input.id,
           userId: ctx.userId,
-          deleted: false,
+          deletedAt: {
+            isNull: true,
+          },
         },
         with: {
           image: true,
@@ -532,7 +537,9 @@ export const gameRouter = createTRPCRouter({
         where: {
           id: input.id,
           userId: ctx.userId,
-          deleted: false,
+          deletedAt: {
+            isNull: true,
+          },
         },
         with: {
           image: true,
@@ -896,7 +903,9 @@ export const gameRouter = createTRPCRouter({
         where: {
           id: input.id,
           userId: ctx.userId,
-          deleted: false,
+          deletedAt: {
+            isNull: true,
+          },
         },
         columns: {
           name: true,
@@ -912,7 +921,9 @@ export const gameRouter = createTRPCRouter({
         where: {
           id: input.id,
           userId: ctx.userId,
-          deleted: false,
+          deletedAt: {
+            isNull: true,
+          },
         },
         with: {
           matches: {
@@ -1005,7 +1016,12 @@ export const gameRouter = createTRPCRouter({
         yearPublished: true,
         ownedBy: true,
       },
-      where: { userId: ctx.userId, deleted: false },
+      where: {
+        userId: ctx.userId,
+        deletedAt: {
+          isNull: true,
+        },
+      },
       with: {
         image: true,
         matches: {
@@ -1436,20 +1452,47 @@ export const gameRouter = createTRPCRouter({
       }
       if (input.scoresheetsToDelete.length > 0) {
         await ctx.db
-          .delete(round)
-          .where(inArray(round.scoresheetId, input.scoresheetsToDelete));
-        await ctx.db
-          .delete(scoresheet)
+          .update(scoresheet)
+          .set({ deletedAt: new Date() })
           .where(inArray(scoresheet.id, input.scoresheetsToDelete));
       }
     }),
   deleteGame: protectedUserProcedure
     .input(selectGameSchema.pick({ id: true }))
     .mutation(async ({ ctx, input }) => {
-      await ctx.db
-        .update(game)
-        .set({ deleted: true })
-        .where(and(eq(game.id, input.id), eq(game.userId, ctx.userId)));
+      await ctx.db.transaction(async (tx) => {
+        await tx
+          .update(sharedGame)
+          .set({ linkedGameId: null })
+          .where(
+            and(
+              eq(sharedGame.linkedGameId, input.id),
+              eq(sharedGame.sharedWithId, ctx.userId),
+            ),
+          );
+        const updatedMatches = await tx
+          .update(match)
+          .set({ deletedAt: new Date() })
+          .where(and(eq(match.gameId, input.id), eq(game.userId, ctx.userId)))
+          .returning();
+        await tx
+          .update(matchPlayer)
+          .set({ deletedAt: new Date() })
+          .where(
+            inArray(
+              matchPlayer.matchId,
+              updatedMatches.map((uMatch) => uMatch.id),
+            ),
+          );
+        await tx
+          .update(scoresheet)
+          .set({ deletedAt: new Date() })
+          .where(eq(scoresheet.gameId, input.id));
+        await tx
+          .update(game)
+          .set({ deletedAt: new Date() })
+          .where(and(eq(game.id, input.id), eq(game.userId, ctx.userId)));
+      });
     }),
   insertGames: protectedUserProcedure
     .input(
@@ -1543,7 +1586,9 @@ export const gameRouter = createTRPCRouter({
       const currentGames = await ctx.db.query.game.findMany({
         where: {
           userId: ctx.userId,
-          deleted: false,
+          deletedAt: {
+            isNull: true,
+          },
         },
       });
       if (currentGames.length > 0) {

--- a/packages/api/src/routers/group.ts
+++ b/packages/api/src/routers/group.ts
@@ -62,15 +62,13 @@ export const groupRouter = createTRPCRouter({
       insertGroupSchema.pick({ name: true, id: true }).required({ id: true }),
     )
     .mutation(async ({ ctx, input }) => {
-      const result = (
-        await ctx.db
-          .update(group)
-          .set({
-            name: input.name,
-          })
-          .where(eq(group.id, input.id))
-          .returning()
-      )[0];
+      const [result] = await ctx.db
+        .update(group)
+        .set({
+          name: input.name,
+        })
+        .where(eq(group.id, input.id))
+        .returning();
       if (!result)
         throw new TRPCError({ code: "NOT_FOUND", message: "Group not found" });
       return result;

--- a/packages/api/src/routers/match.ts
+++ b/packages/api/src/routers/match.ts
@@ -781,9 +781,18 @@ export const matchRouter = createTRPCRouter({
       }),
     )
     .query(async ({ ctx, input }) => {
+      const year = input.date.getUTCFullYear();
+      const month = input.date.getUTCMonth();
+      const day = input.date.getUTCDate();
+
+      const dayStartUtc = new Date(Date.UTC(year, month, day, 0, 0, 0));
+      const nextDayUtc = new Date(Date.UTC(year, month, day + 1, 0, 0, 0));
       const matches = await ctx.db.query.match.findMany({
         where: {
-          RAW: sql`date_trunc('day', ${match.date}) = date_trunc('day', ${input.date}::date)`,
+          date: {
+            gte: dayStartUtc,
+            lt: nextDayUtc,
+          },
           userId: ctx.userId,
           deletedAt: {
             isNull: true,

--- a/packages/api/src/routers/sharing/share-meta.ts
+++ b/packages/api/src/routers/sharing/share-meta.ts
@@ -509,7 +509,9 @@ export const shareMetaRouter = createTRPCRouter({
   getUserGamesForLinking: protectedUserProcedure.query(async ({ ctx }) => {
     const games = await ctx.db.query.game.findMany({
       where: {
-        deleted: false,
+        deletedAt: {
+          isNull: true,
+        },
         userId: ctx.userId,
       },
       with: {
@@ -576,6 +578,9 @@ export const shareMetaRouter = createTRPCRouter({
     const players = await ctx.db.query.player.findMany({
       where: {
         createdBy: ctx.userId,
+        deletedAt: {
+          isNull: true,
+        },
       },
       with: {
         image: true,
@@ -587,6 +592,9 @@ export const shareMetaRouter = createTRPCRouter({
     const locations = await ctx.db.query.location.findMany({
       where: {
         createdBy: ctx.userId,
+        deletedAt: {
+          isNull: true,
+        },
       },
     });
     return locations;

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -21,7 +21,9 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.matchPlayer.matchId.through(r.match.gameId),
       to: r.game.id.through(r.match.gameId),
       where: {
-        deleted: false,
+        deletedAt: {
+          isNull: true,
+        },
       },
     }),
     player: r.one.player({
@@ -71,6 +73,7 @@ export const relations = defineRelations(schema, (r) => ({
     scoresheet: r.one.scoresheet({
       from: r.round.scoresheetId,
       to: r.scoresheet.id,
+      optional: false,
     }),
   },
   userSharingPreference: {
@@ -108,14 +111,29 @@ export const relations = defineRelations(schema, (r) => ({
     createdPlayers: r.many.player({
       from: r.user.id,
       to: r.player.createdBy,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     games: r.many.game({
       from: r.user.id,
       to: r.game.userId,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     matches: r.many.match({
       from: r.user.id,
       to: r.match.userId,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     sharedGamesOwner: r.many.sharedGame({
       from: r.user.id,
@@ -194,6 +212,11 @@ export const relations = defineRelations(schema, (r) => ({
     players: r.many.player({
       from: r.group.id.through(r.groupPlayer.groupId),
       to: r.player.id.through(r.groupPlayer.playerId),
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
   },
   sharedGame: {
@@ -205,6 +228,11 @@ export const relations = defineRelations(schema, (r) => ({
     linkedGame: r.one.game({
       from: r.sharedGame.linkedGameId,
       to: r.game.id,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     owner: r.one.user({
       from: r.sharedGame.ownerId,
@@ -248,12 +276,20 @@ export const relations = defineRelations(schema, (r) => ({
     matches: r.many.match({
       from: r.game.id,
       to: r.match.gameId,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     finishedMatches: r.many.match({
       from: r.game.id,
       to: r.match.gameId,
       where: {
         finished: true,
+        deletedAt: {
+          isNull: true,
+        },
       },
     }),
     sharedGameMatches: r.many.sharedMatch({
@@ -265,6 +301,9 @@ export const relations = defineRelations(schema, (r) => ({
       to: r.scoresheet.gameId,
       where: {
         OR: [{ type: "Default" }, { type: "Game" }],
+        deletedAt: {
+          isNull: true,
+        },
       },
     }),
   },
@@ -276,6 +315,11 @@ export const relations = defineRelations(schema, (r) => ({
     matches: r.many.match({
       from: r.location.id,
       to: r.match.locationId,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     linkedLocations: r.many.sharedLocation({
       from: r.location.id,
@@ -333,6 +377,11 @@ export const relations = defineRelations(schema, (r) => ({
     matches: r.many.match({
       from: r.player.id.through(r.matchPlayer.playerId),
       to: r.match.id.through(r.matchPlayer.matchId),
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     sharedPlayers: r.many.sharedPlayer({
       from: r.player.id,
@@ -349,6 +398,11 @@ export const relations = defineRelations(schema, (r) => ({
     matchPlayers: r.many.matchPlayer({
       from: r.player.id,
       to: r.matchPlayer.playerId,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
   },
   sharedPlayer: {
@@ -370,6 +424,11 @@ export const relations = defineRelations(schema, (r) => ({
     linkedPlayer: r.one.player({
       from: r.sharedPlayer.linkedPlayerId,
       to: r.player.id,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     sharedMatches: r.many.sharedMatch({
       from: r.sharedPlayer.playerId.through(r.sharedMatchPlayer.sharedPlayerId),
@@ -457,10 +516,20 @@ export const relations = defineRelations(schema, (r) => ({
     matchPlayers: r.many.matchPlayer({
       from: r.match.id,
       to: r.matchPlayer.matchId,
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     players: r.many.player({
       from: r.match.id.through(r.matchPlayer.matchId),
       to: r.player.id.through(r.matchPlayer.playerId),
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     teams: r.many.team({
       from: r.match.id,
@@ -510,6 +579,7 @@ export const relations = defineRelations(schema, (r) => ({
     game: r.one.game({
       from: r.scoresheet.gameId,
       to: r.game.id,
+      optional: false,
     }),
     sharedScoresheets: r.many.sharedScoresheet({
       from: r.scoresheet.id,
@@ -532,10 +602,16 @@ export const relations = defineRelations(schema, (r) => ({
     players: r.many.player({
       from: r.team.id.through(r.matchPlayer.teamId),
       to: r.player.id.through(r.matchPlayer.playerId),
+      where: {
+        deletedAt: {
+          isNull: true,
+        },
+      },
     }),
     match: r.one.match({
       from: r.team.matchId,
       to: r.match.id,
+      optional: false,
     }),
   },
   shareRequest: {

--- a/packages/db/src/schema/game.ts
+++ b/packages/db/src/schema/game.ts
@@ -34,7 +34,7 @@ const games = createTable(
     yearPublished: integer("year_published"),
     description: text("description"),
     rules: text("rules"),
-    deleted: boolean("deleted").default(false),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
     index("boardgames_game_user_id_index").on(table.userId),

--- a/packages/db/src/schema/match.ts
+++ b/packages/db/src/schema/match.ts
@@ -33,6 +33,7 @@ const matches = createTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
       () => new Date(),
     ),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     date: timestamp("date", { withTimezone: true })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),

--- a/packages/db/src/schema/matchPlayer.ts
+++ b/packages/db/src/schema/matchPlayer.ts
@@ -35,6 +35,7 @@ const matchPlayers = createTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
       () => new Date(),
     ),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
     unique("boardgames_match_player_match_id_player_id_unique").on(

--- a/packages/db/src/schema/player.ts
+++ b/packages/db/src/schema/player.ts
@@ -27,6 +27,7 @@ const players = createTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
       () => new Date(),
     ),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
     index("name_idx").on(table.name),

--- a/packages/db/src/schema/scoresheet.ts
+++ b/packages/db/src/schema/scoresheet.ts
@@ -29,6 +29,7 @@ const scoresheets = createTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
       () => new Date(),
     ),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     isCoop: boolean("is_coop").default(false).notNull(),
     winCondition: text("win_condition", {
       enum: [


### PR DESCRIPTION

Closes #<issue>

## ✅ Checklist

- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)  
- [ ] I performed a functional test on my final commit

---

## Changelog

- Replace boolean `deleted` flags with `deletedAt` timestamps in `game`, `match`, `matchPlayer`, `player`, and `scoresheet` schemas to support soft deletion.  
- Update related queries and mutations in routers to filter out soft-deleted records, ensuring data integrity and improved retrieval.  
- Refactor existing logic in the dashboard, game, match, and player routers to accommodate the new soft deletion approach, enhancing overall application consistency.

---

## Screenshots

_None (database changes only)_ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a soft-delete mechanism using a deletion timestamp across games, matches, players, match players, and scoresheets.
  - Enabled tracking of deletion times without permanently removing records.

- **Bug Fixes**
  - Ensured soft-deleted records are consistently excluded from queries and dashboards.

- **Refactor**
  - Updated queries and mutations to filter by deletion timestamp instead of a boolean flag.
  - Enhanced deletion logic to cascade soft-deletes and maintain data integrity.
  - Rewrote match and player mutations to support transactional soft deletes, preserve team scores, and recalculate placements.
  - Improved calendar components to use declarative navigation and enriched match data structures.

- **Chores**
  - Modified database schemas and relationships to incorporate the new soft-delete timestamp.
  - Clarified relation optionality and tightened filtering criteria for deleted records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->