### PR TITLE
feat(dashboard): add prefetching to links across various components

### DIFF
--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/summary/_components/match-summary.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/summary/_components/match-summary.tsx
@@ -106,8 +106,9 @@ export default function MatchSummary({ matchId }: { matchId: number }) {
                 <div className="flex gap-2 p-1 sm:p-4">
                   {match.previousMatches.map((match) => (
                     <Link
-                      href={`/dashboard/games${match.type === "shared" ? "/shared" : ""}/${match.gameId}/${match.id}${match.finished ? "/summary" : ""}`}
                       key={match.id}
+                      prefetch={true}
+                      href={`/dashboard/games${match.type === "shared" ? "/shared" : ""}/${match.gameId}/${match.id}${match.finished ? "/summary" : ""}`}
                       className="block h-40 w-64 rounded-lg border p-4 transition-colors hover:bg-muted/50"
                     >
                       <h3 className="truncate font-medium">{match.name}</h3>

--- a/apps/nextjs/src/app/dashboard/games/_components/game-card.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/game-card.tsx
@@ -55,6 +55,7 @@ export function GameCard({ game }: GameCardProps) {
     <Card className="relative flex h-full flex-col overflow-hidden transition-shadow hover:shadow-md">
       <div className="flex flex-row items-center">
         <Link
+          prefetch={true}
           href={
             game.type === "shared"
               ? `/dashboard/games/shared/${game.id}`
@@ -68,6 +69,7 @@ export function GameCard({ game }: GameCardProps) {
                 src={game.image}
                 alt={`${game.name} game image`}
                 className="aspect-square h-full w-full rounded-md object-cover"
+                quality={65}
               />
             ) : (
               <Dices className="h-full w-full items-center justify-center rounded-md bg-muted p-2" />

--- a/apps/nextjs/src/app/dashboard/games/_components/gamesDropDown.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/gamesDropDown.tsx
@@ -58,6 +58,7 @@ export function GamesDropDown({
         {data.type === "original" && (
           <DropdownMenuItem asChild>
             <Link
+              prefetch={true}
               href={`/dashboard/games/${data.id}/edit`}
               className="flex items-center gap-2"
             >
@@ -68,6 +69,7 @@ export function GamesDropDown({
         )}
         <DropdownMenuItem asChild>
           <Link
+            prefetch={true}
             href={
               data.type === "shared"
                 ? `/dashboard/games/shared/${data.id}/stats`
@@ -89,6 +91,7 @@ export function GamesDropDown({
           <>
             <DropdownMenuItem asChild>
               <Link
+                prefetch={true}
                 href={`/dashboard/games/${data.id}/share`}
                 className="flex items-center gap-2"
               >

--- a/apps/nextjs/src/app/dashboard/games/_components/matches-list.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/matches-list.tsx
@@ -454,6 +454,7 @@ export function MatchesList({ matches, isShared = false }: MatchesListProps) {
                       {/* Match header with name and dropdown */}
                       <div className="flex items-start justify-between">
                         <Link
+                          prefetch={true}
                           href={
                             match.finished
                               ? `/dashboard/games/${match.type === "shared" ? "shared/" : ""}${match.gameId}/${match.id}/summary`

--- a/apps/nextjs/src/app/dashboard/games/_components/matches-list.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/matches-list.tsx
@@ -430,6 +430,7 @@ export function MatchesList({ matches, isShared = false }: MatchesListProps) {
                       )}
                     >
                       <Link
+                        prefetch={true}
                         href={
                           match.finished
                             ? `/dashboard/games/${match.type === "shared" ? "shared/" : ""}${match.gameId}/${match.id}/summary`

--- a/apps/nextjs/src/app/dashboard/games/_components/matchesDropDown.tsx
+++ b/apps/nextjs/src/app/dashboard/games/_components/matchesDropDown.tsx
@@ -72,6 +72,7 @@ export function MatchDropDown({
           {match.type === "original" && (
             <DropdownMenuItem asChild>
               <Link
+                prefetch={true}
                 href={`/dashboard/games/${gameId}/${match.id}/edit`}
                 className="flex items-center gap-2"
               >
@@ -82,6 +83,7 @@ export function MatchDropDown({
           )}
           <DropdownMenuItem asChild>
             <Link
+              prefetch={true}
               href={
                 match.type === "shared"
                   ? `/dashboard/games/shared/${match.gameId}/${match.id}`
@@ -96,6 +98,7 @@ export function MatchDropDown({
           {match.finished && (
             <DropdownMenuItem asChild>
               <Link
+                prefetch={true}
                 href={
                   match.type === "shared"
                     ? `/dashboard/games/shared/${match.gameId}/${match.id}/summary`
@@ -112,6 +115,7 @@ export function MatchDropDown({
             <>
               <DropdownMenuItem asChild>
                 <Link
+                  prefetch={true}
                   href={`/dashboard/games/${gameId}/${match.id}/share`}
                   className="flex items-center gap-2"
                 >

--- a/apps/nextjs/src/app/dashboard/locations/_components/locationsTable.tsx
+++ b/apps/nextjs/src/app/dashboard/locations/_components/locationsTable.tsx
@@ -61,6 +61,7 @@ export function LocationsTable() {
               >
                 <CardContent className="flex w-full items-center justify-between gap-2 p-3 pt-3">
                   <Link
+                    prefetch={true}
                     href={
                       location.type === "shared"
                         ? `/dashboard/locations/shared/${location.id}`

--- a/apps/nextjs/src/app/dashboard/players/_components/players.tsx
+++ b/apps/nextjs/src/app/dashboard/players/_components/players.tsx
@@ -47,7 +47,10 @@ export function PlayersTable() {
             return (
               <Card key={player.id}>
                 <CardContent className="flex w-full items-center justify-between gap-2 p-3 pt-3">
-                  <Link href={`/dashboard/players/${player.id}/stats`}>
+                  <Link
+                    prefetch={true}
+                    href={`/dashboard/players/${player.id}/stats`}
+                  >
                     <div className="flex items-center gap-2">
                       <Avatar className="h-14 w-14 shadow">
                         <AvatarImage

--- a/apps/nextjs/src/components/breadcrumbs.tsx
+++ b/apps/nextjs/src/components/breadcrumbs.tsx
@@ -158,7 +158,9 @@ const RenderBreadCrumbs = ({
                   <BreadcrumbPage>{item.name}</BreadcrumbPage>
                 ) : (
                   <BreadcrumbLink asChild>
-                    <Link href={`/${item.path}`}>{item.name}</Link>
+                    <Link prefetch={true} href={`/${item.path}`}>
+                      {item.name}
+                    </Link>
                   </BreadcrumbLink>
                 )}
               </BreadcrumbItem>

--- a/apps/nextjs/src/components/nav-main.tsx
+++ b/apps/nextjs/src/components/nav-main.tsx
@@ -47,7 +47,7 @@ export async function NavMain() {
           </Suspense>
           <SidebarMenuItem>
             <SidebarMenuButton asChild>
-              <Link href="/dashboard/calendar">
+              <Link prefetch={true} href="/dashboard/calendar">
                 <Calendar1 />
                 <span>{"Calendar"}</span>
               </Link>

--- a/apps/nextjs/src/components/sidebar-items.tsx
+++ b/apps/nextjs/src/components/sidebar-items.tsx
@@ -23,7 +23,7 @@ export function GameItem() {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
-        <Link href="/dashboard/games">
+        <Link prefetch={true} href="/dashboard/games">
           <Dices />
           <span>{"Games"}</span>
         </Link>
@@ -42,11 +42,11 @@ export function GamesItem() {
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton tooltip={"Games"}>
-            <Link href="/dashboard/games">
+            <Link prefetch={true} href="/dashboard/games">
               <Dices />
             </Link>
 
-            <Link href="/dashboard/games">
+            <Link prefetch={true} href="/dashboard/games">
               <span>{"Games"}</span>
             </Link>
             {games.length > 0 && (
@@ -60,7 +60,7 @@ export function GamesItem() {
               {games.map((game) => (
                 <SidebarMenuSubItem key={game.id}>
                   <SidebarMenuSubButton asChild>
-                    <Link href={`/dashboard/games/${game.id}`}>
+                    <Link prefetch={true} href={`/dashboard/games/${game.id}`}>
                       <span>{game.name}</span>
                     </Link>
                   </SidebarMenuSubButton>
@@ -78,7 +78,7 @@ export function PlayerItem() {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
-        <Link href="/dashboard/players">
+        <Link prefetch={true} href="/dashboard/players">
           <User />
           <span>{"Players"}</span>
         </Link>
@@ -97,11 +97,11 @@ export function PlayersItem() {
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton tooltip={"Players"}>
-            <Link href="/dashboard/players">
+            <Link prefetch={true} href="/dashboard/players">
               <User />
             </Link>
 
-            <Link href="/dashboard/players">
+            <Link prefetch={true} href="/dashboard/players">
               <span>{"Players"}</span>
             </Link>
             {players.length > 0 && (
@@ -115,7 +115,10 @@ export function PlayersItem() {
               {players.map((player) => (
                 <SidebarMenuSubItem key={player.id}>
                   <SidebarMenuSubButton asChild>
-                    <Link href={`/dashboard/players/${player.id}/stats`}>
+                    <Link
+                      prefetch={true}
+                      href={`/dashboard/players/${player.id}/stats`}
+                    >
                       <span>{player.name}</span>
                     </Link>
                   </SidebarMenuSubButton>
@@ -133,7 +136,7 @@ export function GroupItem() {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
-        <Link href="/dashboard/groups">
+        <Link prefetch={true} href="/dashboard/groups">
           <UsersRound />
           <span>{"Groups"}</span>
         </Link>
@@ -151,11 +154,11 @@ export function GroupsItem() {
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton tooltip={"Groups"}>
-            <Link href="/dashboard/groups">
+            <Link prefetch={true} href="/dashboard/groups">
               <UsersRound />
             </Link>
 
-            <Link href="/dashboard/groups">
+            <Link prefetch={true} href="/dashboard/groups">
               <span>{"Groups"}</span>
             </Link>
             {groups.length > 0 && (
@@ -169,7 +172,10 @@ export function GroupsItem() {
               {groups.map((group) => (
                 <SidebarMenuSubItem key={group.id}>
                   <SidebarMenuSubButton asChild>
-                    <Link href={`/dashboard/groups/${group.id}`}>
+                    <Link
+                      prefetch={true}
+                      href={`/dashboard/groups/${group.id}`}
+                    >
                       <span>{group.name}</span>
                     </Link>
                   </SidebarMenuSubButton>
@@ -187,7 +193,7 @@ export function LocationItem() {
   return (
     <SidebarMenuItem>
       <SidebarMenuButton asChild>
-        <Link href="/dashboard/locations">
+        <Link prefetch={true} href="/dashboard/locations">
           <Map />
           <span>{"Locations"}</span>
         </Link>
@@ -205,11 +211,11 @@ export function LocationsItem() {
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton tooltip={"Locations"}>
-            <Link href="/dashboard/locations">
+            <Link prefetch={true} href="/dashboard/locations">
               <Map />
             </Link>
 
-            <Link href="/dashboard/locations">
+            <Link prefetch={true} href="/dashboard/locations">
               <span>{"Locations"}</span>
             </Link>
             {locations.length > 0 && (
@@ -223,7 +229,10 @@ export function LocationsItem() {
               {locations.map((location) => (
                 <SidebarMenuSubItem key={location.id}>
                   <SidebarMenuSubButton asChild>
-                    <Link href={`/dashboard/locations/${location.id}`}>
+                    <Link
+                      prefetch={true}
+                      href={`/dashboard/locations/${location.id}`}
+                    >
                       <span>{location.name}</span>
                     </Link>
                   </SidebarMenuSubButton>


### PR DESCRIPTION


Closes #<issue>

## ✅ Checklist

- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Implement prefetching for links in MatchSummary, GameCard, GamesDropDown, MatchesList, MatchDropDown, LocationsTable, PlayersTable, Breadcrumbs, NavMain, and SidebarItems components to enhance navigation performance.
- Update link structures to include prefetch attribute, improving user experience by reducing load times when navigating between pages.

---

## Screenshots

_[Screenshots]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Enabled prefetching for all navigation links across dashboard components, sidebar, breadcrumbs, and dropdowns to improve page load speed and navigation responsiveness.
  - Optimized image loading in game cards by adjusting image quality settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->