### PR TITLE
feat(ui-components): add user profile page, navigation prefetch, sidebar header, and Alert component

### DIFF
--- a/apps/nextjs/src/app/dashboard/user-profile/_components/profile-connected-accounts.tsx
+++ b/apps/nextjs/src/app/dashboard/user-profile/_components/profile-connected-accounts.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { AlertCircle, Loader2, Mail } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@board-games/ui/alert";
+import { Button } from "@board-games/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@board-games/ui/card";
+import { useToast } from "@board-games/ui/hooks/use-toast";
+import { Icons } from "@board-games/ui/icons";
+
+import type { SerializableUser } from "../page";
+
+interface ProfileConnectedAccountsProps {
+  serializableUser: SerializableUser;
+}
+
+export function ProfileConnectedAccounts({
+  serializableUser,
+}: ProfileConnectedAccountsProps) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [isConnectingGoogle, setIsConnectingGoogle] = useState(false);
+  const [isConnectingGithub, setIsConnectingGithub] = useState(false);
+  const { user } = useUser();
+
+  // In a real app, these would come from the user object
+  // For this example, we'll simulate some connected accounts
+  const connectedAccounts = {
+    google: user?.externalAccounts.find(
+      (account) => account.provider === "google",
+    ),
+    github: user?.externalAccounts.find(
+      (account) => account.provider === "github",
+    ),
+  };
+
+  const connectGoogle = async () => {
+    if (!user) return;
+
+    setIsConnectingGoogle(true);
+
+    await user
+      .createExternalAccount({
+        strategy: "oauth_google",
+        redirectUrl: "/dashboard/user-profile/profile?tab=connected",
+      })
+      .then((res) => {
+        console.log(res);
+        toast({
+          title: "Google account connected",
+          description: "Your Google account has been successfully linked.",
+        });
+        router.refresh();
+      })
+      .catch((err) => {
+        console.error("Error connecting Google account", err);
+        toast({
+          title: "Connection failed",
+          description:
+            "Failed to connect your Google account. Please try again.",
+          variant: "destructive",
+        });
+      })
+      .finally(() => setIsConnectingGoogle(false));
+  };
+
+  const connectGithub = async () => {
+    if (!user) return;
+    setIsConnectingGithub(true);
+    await user
+      .createExternalAccount({
+        strategy: "oauth_github",
+        redirectUrl: "/dashboard/user-profile/profile?tab=connected",
+      })
+      .then((res) => {
+        console.log(res);
+        toast({
+          title: "GitHub account connected",
+          description: "Your GitHub account has been successfully linked.",
+        });
+        router.refresh();
+      })
+      .catch((err) => {
+        console.error("Error connecting GitHub account", err);
+        toast({
+          title: "Connection failed",
+          description:
+            "Failed to connect your GitHub account. Please try again.",
+          variant: "destructive",
+        });
+      })
+      .finally(() => setIsConnectingGithub(false));
+  };
+
+  const disconnectAccount = async (provider: string) => {
+    if (!user) {
+      toast({
+        title: "Not logged in",
+        description: "Please log in to disconnect your account",
+      });
+      return;
+    }
+    try {
+      // In a real implementation, you would use Clerk's API to disconnect the account
+      // For example:
+      await user.externalAccounts
+        .find((account) => account.provider === provider)
+        ?.destroy();
+
+      toast({
+        title: `${provider} account disconnected`,
+        description: `Your ${provider} account has been successfully unlinked.`,
+      });
+
+      router.refresh();
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: "Disconnection failed",
+        description: `Failed to disconnect your ${provider} account. Please try again.`,
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Connected Accounts</CardTitle>
+          <CardDescription>
+            Connect your accounts to enable single sign-on and enhance your
+            profile
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Primary Email */}
+          <div className="rounded-md border">
+            <div className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-4">
+                <div className="rounded-full bg-primary/10 p-2">
+                  <Mail className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="font-medium">Email Address</p>
+                  <p className="text-sm text-muted-foreground">
+                    {serializableUser.primaryEmailAddress ??
+                      "No email address connected"}
+                  </p>
+                </div>
+              </div>
+              <div>
+                <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold">
+                  Primary
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Google Account */}
+          <div className="rounded-md border">
+            <div className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-4">
+                <div className="rounded-full bg-primary/10 p-2">
+                  <Icons.google className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="font-medium">Google</p>
+                  <p className="text-sm text-muted-foreground">
+                    {connectedAccounts.google
+                      ? "Connected to your Google account"
+                      : "Connect your Google account for easier sign-in"}
+                  </p>
+                </div>
+              </div>
+              {connectedAccounts.google ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => disconnectAccount("Google")}
+                >
+                  Disconnect
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={connectGoogle}
+                  disabled={isConnectingGoogle}
+                >
+                  {isConnectingGoogle ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Connecting...
+                    </>
+                  ) : (
+                    "Connect"
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {/* GitHub Account */}
+          <div className="rounded-md border">
+            <div className="flex items-center justify-between p-4">
+              <div className="flex items-center gap-4">
+                <div className="rounded-full bg-primary/10 p-2">
+                  <Icons.gitHub className="h-5 w-5 text-primary" />
+                </div>
+                <div>
+                  <p className="font-medium">GitHub</p>
+                  <p className="text-sm text-muted-foreground">
+                    {connectedAccounts.github
+                      ? "Connected to your GitHub account"
+                      : "Connect your GitHub account for easier sign-in"}
+                  </p>
+                </div>
+              </div>
+              {connectedAccounts.github ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => disconnectAccount("GitHub")}
+                >
+                  Disconnect
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={connectGithub}
+                  disabled={isConnectingGithub}
+                >
+                  {isConnectingGithub ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Connecting...
+                    </>
+                  ) : (
+                    "Connect"
+                  )}
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Account Security</AlertTitle>
+            <AlertDescription>
+              Connecting multiple accounts enhances security and provides backup
+              sign-in methods.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/user-profile/_components/profile-details.tsx
+++ b/apps/nextjs/src/app/dashboard/user-profile/_components/profile-details.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import type { User } from "@clerk/nextjs/server";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Button } from "@board-games/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@board-games/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@board-games/ui/form";
+import { useToast } from "@board-games/ui/hooks/use-toast";
+import { Input } from "@board-games/ui/input";
+
+import type { SerializableUser } from "../page";
+
+const profileFormSchema = z.object({
+  firstName: z.string().min(2, "First name must be at least 2 characters."),
+  lastName: z.string().min(2, "Last name must be at least 2 characters."),
+  username: z.string().min(2, "Username must be at least 2 characters."),
+});
+
+type ProfileFormValues = z.infer<typeof profileFormSchema>;
+
+interface ProfileDetailsProps {
+  serializableUser: SerializableUser;
+}
+
+export function ProfileDetails({ serializableUser }: ProfileDetailsProps) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const { user } = useUser();
+
+  const defaultValues: Partial<ProfileFormValues> = {
+    firstName: serializableUser.firstName ?? "",
+    lastName: serializableUser.lastName ?? "",
+    username: serializableUser.username ?? "",
+  };
+
+  const form = useForm<ProfileFormValues>({
+    resolver: zodResolver(profileFormSchema),
+    defaultValues,
+  });
+
+  async function onSubmit(data: ProfileFormValues) {
+    setIsLoading(true);
+    if (!user) {
+      toast({
+        title: "Not logged in",
+      });
+      return;
+    }
+    try {
+      await user.update({
+        firstName: data.firstName,
+        lastName: data.lastName,
+        username: data.username,
+      });
+
+      toast({
+        title: "Profile updated",
+        description: "Your profile has been updated successfully.",
+      });
+
+      router.refresh();
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "Failed to update profile. Please try again.",
+        variant: "destructive",
+      });
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Personal Information</CardTitle>
+        <CardDescription>
+          Update your personal information and how others see you on the
+          platform.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="John" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Doe" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="username"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Username</FormLabel>
+                  <FormControl>
+                    <Input placeholder="johndoe" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    This is your public username. It can only contain letters,
+                    numbers, and underscores.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end">
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? "Saving..." : "Save Changes"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/user-profile/_components/profile-header.tsx
+++ b/apps/nextjs/src/app/dashboard/user-profile/_components/profile-header.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Camera, Mail } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@board-games/ui/avatar";
+import { Button } from "@board-games/ui/button";
+import { Card, CardContent } from "@board-games/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@board-games/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@board-games/ui/form";
+import { useToast } from "@board-games/ui/hooks/use-toast";
+import { Input } from "@board-games/ui/input";
+
+import type { SerializableUser } from "../page";
+import { Spinner } from "~/components/spinner";
+
+interface ProfileHeaderProps {
+  user: SerializableUser;
+}
+
+export function ProfileHeader({ user }: ProfileHeaderProps) {
+  const [isEditPictureOpen, setIsEditPictureOpen] = useState(false);
+  const initials = `${user.firstName ?? ""}${user.lastName?.[0] ?? ""}`;
+
+  return (
+    <>
+      <Card>
+        <CardContent className="p-6">
+          <div className="flex flex-col items-start gap-6 md:flex-row md:items-center">
+            <div className="relative">
+              <Avatar className="h-24 w-24">
+                <AvatarImage
+                  src={user.imageUrl}
+                  alt={user.fullName ?? "User"}
+                />
+                <AvatarFallback className="text-lg">{initials}</AvatarFallback>
+              </Avatar>
+              <Button
+                size="icon"
+                variant="secondary"
+                className="absolute -bottom-2 -right-2 h-8 w-8 rounded-full"
+                onClick={() => setIsEditPictureOpen(true)}
+              >
+                <Camera className="h-4 w-4" />
+                <span className="sr-only">Change profile picture</span>
+              </Button>
+            </div>
+
+            <div className="space-y-1.5">
+              <h1 className="text-2xl font-bold">{user.fullName}</h1>
+              <div className="flex flex-col gap-2 text-sm text-muted-foreground sm:flex-row sm:gap-6">
+                {user.primaryEmailAddress && (
+                  <div className="flex items-center gap-1">
+                    <Mail className="h-4 w-4" />
+                    <span>{user.primaryEmailAddress}</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <EditProfilePictureDialog
+        serializableUser={user}
+        isOpen={isEditPictureOpen}
+        setIsOpen={setIsEditPictureOpen}
+      />
+    </>
+  );
+}
+
+interface EditProfilePictureDialogProps {
+  serializableUser: SerializableUser;
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+function EditProfilePictureDialog({
+  serializableUser,
+  isOpen,
+  setIsOpen,
+}: EditProfilePictureDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogContent className="sm:max-w-[425px]">
+        <EditProfilePictureContent
+          serializableUser={serializableUser}
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditProfilePictureContent({
+  serializableUser,
+  setIsOpen,
+}: EditProfilePictureDialogProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [imagePreview, setImagePreview] = useState<string | null>(null);
+
+  const { toast } = useToast();
+  const { user } = useUser();
+
+  useEffect(() => {
+    return () => {
+      if (imagePreview) {
+        URL.revokeObjectURL(imagePreview);
+      }
+    };
+  }, [imagePreview]);
+
+  const EditProfileSchema = z
+    .object({
+      file: z
+        .instanceof(File)
+        .refine(
+          (file) => file.size <= 4 * 1024 * 1024,
+          `Max image size is 4MB.`,
+        )
+        .refine(
+          (file) => file.type === "image/jpeg" || file.type === "image/png",
+          "Only .jpg and .png formats are supported.",
+        )
+        .or(z.string().nullable()),
+    })
+    .superRefine((values, ctx) => {
+      if (serializableUser.imageUrl === values.file) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Image cannot be the same as current image.",
+          path: ["file"],
+        });
+      }
+    });
+
+  const form = useForm<z.infer<typeof EditProfileSchema>>({
+    resolver: zodResolver(EditProfileSchema),
+    defaultValues: {
+      file: serializableUser.imageUrl,
+    },
+  });
+
+  const initials = `${serializableUser.firstName?.[0] ?? ""}${serializableUser.lastName?.[0] ?? ""}`;
+
+  async function onSubmit(data: z.infer<typeof EditProfileSchema>) {
+    console.log("submit");
+    setIsLoading(true);
+    if (!user) return;
+    if (serializableUser.imageUrl === data.file) {
+      setIsLoading(false);
+      return;
+    }
+    await user
+      .setProfileImage({ file: data.file })
+      .then(() => {
+        toast({
+          title: "Profile picture updated",
+          description: "Your profile picture has been updated successfully.",
+        });
+
+        router.refresh();
+        setIsOpen(false);
+      })
+      .catch((error) => {
+        console.error(error);
+        toast({
+          title: "Error",
+          description: "Failed to update profile picture. Please try again.",
+          variant: "destructive",
+        });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <DialogHeader>
+          <DialogTitle>Update Profile Picture</DialogTitle>
+          <DialogDescription>
+            Upload a new profile picture or avatar.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex w-full items-center justify-center">
+          <FormField
+            control={form.control}
+            name="file"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  <Avatar className="h-32 w-32">
+                    <AvatarImage
+                      src={imagePreview ?? serializableUser.imageUrl}
+                      alt={serializableUser.fullName ?? "User"}
+                    />
+                    <AvatarFallback className="text-2xl">
+                      {initials}
+                    </AvatarFallback>
+                  </Avatar>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    className="hidden"
+                    type="file"
+                    accept="image/*"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      field.onChange(file);
+                      if (file) {
+                        const url = URL.createObjectURL(file);
+                        setImagePreview(url);
+                      }
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>Upload an image (max 4MB).</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <DialogFooter className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+          <Button
+            variant="outline"
+            onClick={() => setIsOpen(false)}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Spinner />
+                <span>Uploading...</span>
+              </>
+            ) : (
+              "Submit"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/user-profile/_components/profile-security.tsx
+++ b/apps/nextjs/src/app/dashboard/user-profile/_components/profile-security.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import type { SessionWithActivitiesResource } from "@clerk/types";
+import { useEffect, useState } from "react";
+import { useSession, useUser } from "@clerk/nextjs";
+import { compareDesc, formatDistanceToNow } from "date-fns";
+import {
+  Clock,
+  Globe,
+  Laptop,
+  MapPin,
+  Monitor,
+  SmartphoneIcon,
+  Tablet,
+} from "lucide-react";
+
+import { Badge } from "@board-games/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@board-games/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@board-games/ui/tooltip";
+
+export function ProfileSecurity() {
+  const { user } = useUser();
+  const { session: currentSession } = useSession();
+  const [sessionList, setSessionList] = useState<
+    SessionWithActivitiesResource[]
+  >([]);
+
+  useEffect(() => {
+    async function getData() {
+      if (!user) return;
+      const res = await user.getSessions();
+      setSessionList(res);
+    }
+    void getData();
+  }, [user]);
+
+  const getDeviceIcon = (session: SessionWithActivitiesResource) => {
+    const { deviceType, isMobile } = session.latestActivity;
+
+    if (
+      deviceType?.toLowerCase().includes("iphone") ||
+      deviceType?.toLowerCase().includes("android")
+    ) {
+      return <SmartphoneIcon className="h-5 w-5" />;
+    } else if (deviceType?.toLowerCase().includes("ipad")) {
+      return <Tablet className="h-5 w-5" />;
+    } else if (
+      deviceType?.toLowerCase().includes("macbook") ||
+      deviceType?.toLowerCase().includes("laptop")
+    ) {
+      return <Laptop className="h-5 w-5" />;
+    } else if (isMobile) {
+      return <SmartphoneIcon className="h-5 w-5" />;
+    } else {
+      return <Monitor className="h-5 w-5" />;
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Security Log</CardTitle>
+          <CardDescription>
+            Review recent security activity on your account
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {sessionList
+            .toSorted((a, b) => compareDesc(a.lastActiveAt, b.lastActiveAt))
+            .map((session) => {
+              const isCurrent = currentSession?.id === session.id;
+              const {
+                city,
+                country,
+                browserName,
+                browserVersion,
+                deviceType,
+                ipAddress,
+                isMobile,
+              } = session.latestActivity;
+
+              const title =
+                (deviceType ?? isMobile) ? "Mobile device" : "Desktop device";
+
+              const browser =
+                `${browserName ?? ""} ${browserVersion ?? ""}`.trim() ||
+                "Web browser";
+
+              const location =
+                [city ?? "", country ?? ""].filter(Boolean).join(", ").trim() ||
+                "Unknown location";
+
+              const lastActive = formatDistanceToNow(session.lastActiveAt, {
+                addSuffix: true,
+              });
+              const isActive = session.status === "active";
+
+              return (
+                <div
+                  key={session.id}
+                  className={`rounded-lg border p-4 ${isCurrent ? "border-primary/20 bg-primary/5" : ""} ${!isActive ? "opacity-60" : ""}`}
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-start gap-4">
+                      <div
+                        className={`rounded-full p-2 ${isCurrent ? "bg-primary/10" : "bg-muted"}`}
+                      >
+                        {getDeviceIcon(session)}
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium">{title}</p>
+                          {isCurrent && (
+                            <Badge
+                              variant="outline"
+                              className="border-primary/20 bg-primary/10 text-xs text-primary"
+                            >
+                              Current
+                            </Badge>
+                          )}
+                          {!isActive && (
+                            <Badge
+                              variant="outline"
+                              className="border-destructive/20 bg-destructive/10 text-xs text-destructive"
+                            >
+                              Terminated
+                            </Badge>
+                          )}
+                        </div>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {browser}
+                        </p>
+                        <div className="mt-2 flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center sm:gap-3">
+                          <div className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            <span>
+                              {isCurrent
+                                ? "Active now"
+                                : `Last active ${lastActive}`}
+                            </span>
+                          </div>
+                          <div className="hidden sm:block">•</div>
+                          <div className="flex items-center gap-1">
+                            <MapPin className="h-3 w-3" />
+                            <span>{location}</span>
+                          </div>
+                          <div className="hidden sm:block">•</div>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="flex cursor-help items-center gap-1">
+                                <Globe className="h-3 w-3" />
+                                <span>{ipAddress ?? "Unknown IP"}</span>
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>IP Address</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/user-profile/_components/profile-tabs.tsx
+++ b/apps/nextjs/src/app/dashboard/user-profile/_components/profile-tabs.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@board-games/ui/tabs";
+
+import type { SerializableUser } from "../page";
+import { ProfileConnectedAccounts } from "./profile-connected-accounts";
+import { ProfileDetails } from "./profile-details";
+import { ProfileSecurity } from "./profile-security";
+
+interface ProfileTabsProps {
+  user: SerializableUser;
+}
+
+export function ProfileTabs({ user }: ProfileTabsProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleTabChange = (value: string) => {
+    router.push(`${pathname}?tab=${value}`, { scroll: false });
+  };
+  return (
+    <Tabs
+      defaultValue="details"
+      className="w-full"
+      onValueChange={handleTabChange}
+    >
+      <TabsList className="grid w-full grid-cols-3">
+        <TabsTrigger value="details">Personal Info</TabsTrigger>
+        <TabsTrigger value="security">Security</TabsTrigger>
+        <TabsTrigger value="connected">Connected Accounts</TabsTrigger>
+      </TabsList>
+      <TabsContent value="details" className="mt-6">
+        <ProfileDetails serializableUser={user} />
+      </TabsContent>
+      <TabsContent value="security" className="mt-6">
+        <ProfileSecurity />
+      </TabsContent>
+      <TabsContent value="connected" className="mt-6">
+        <ProfileConnectedAccounts serializableUser={user} />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/nextjs/src/app/dashboard/user-profile/page.tsx
+++ b/apps/nextjs/src/app/dashboard/user-profile/page.tsx
@@ -1,0 +1,49 @@
+import type { User } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { currentUser } from "@clerk/nextjs/server";
+
+import { Separator } from "@board-games/ui/separator";
+
+import { ProfileHeader } from "./_components/profile-header";
+import { ProfileTabs } from "./_components/profile-tabs";
+
+export interface SerializableUser {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  fullName: string | null;
+  username: string | null;
+  imageUrl: string;
+  primaryEmailAddress: string | null;
+  publicMetadata: Record<string, unknown>;
+}
+
+function extractUserData(user: User): SerializableUser {
+  return {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    fullName: user.fullName,
+    username: user.username,
+    imageUrl: user.imageUrl,
+    primaryEmailAddress: user.primaryEmailAddress?.emailAddress ?? null,
+    publicMetadata: user.publicMetadata,
+  };
+}
+export default async function ProfilePage() {
+  const user = await currentUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const serializableUser = extractUserData(user);
+
+  return (
+    <div className="container max-w-5xl py-8">
+      <ProfileHeader user={serializableUser} />
+      <Separator className="my-6" />
+      <ProfileTabs user={serializableUser} />
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/sign-in/sso-callback/page.tsx
+++ b/apps/nextjs/src/app/sign-in/sso-callback/page.tsx
@@ -1,0 +1,8 @@
+import { AuthenticateWithRedirectCallback } from "@clerk/nextjs";
+
+export default function Page() {
+  // Handle the redirect flow by calling the Clerk.handleRedirectCallback() method
+  // or rendering the prebuilt <AuthenticateWithRedirectCallback/> component.
+  // This is the final step in the custom OAuth flow.
+  return <AuthenticateWithRedirectCallback />;
+}

--- a/apps/nextjs/src/components/app-sidebar.tsx
+++ b/apps/nextjs/src/components/app-sidebar.tsx
@@ -1,10 +1,16 @@
 import * as React from "react";
+import Link from "next/link";
 import { SignedIn, SignedOut, SignInButton } from "@clerk/nextjs";
+import { Dices } from "lucide-react";
 
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
   SidebarRail,
 } from "@board-games/ui/sidebar";
 
@@ -19,6 +25,22 @@ export async function AppSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" asChild>
+              <Link prefetch={true} href="/dashboard">
+                <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
+                  <Dices className="size-4" />
+                </div>
+                <div className="flex flex-col gap-0.5 leading-none">
+                  <span className="font-semibold">Board Games Tracker</span>
+                </div>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
       <SidebarContent>
         <NavMain />
       </SidebarContent>

--- a/apps/nextjs/src/components/nav-user.tsx
+++ b/apps/nextjs/src/components/nav-user.tsx
@@ -85,6 +85,7 @@ export function NavUser() {
             <DropdownMenuGroup>
               <DropdownMenuItem>
                 <Link
+                  prefetch={true}
                   href="/dashboard/user-profile"
                   className="flex items-center gap-2"
                 >

--- a/apps/nextjs/src/components/nav-user.tsx
+++ b/apps/nextjs/src/components/nav-user.tsx
@@ -1,12 +1,14 @@
 "use client";
 
+import Link from "next/link";
 import { SignOutButton, useUser } from "@clerk/nextjs";
-import { ChevronsUpDown, LogOut } from "lucide-react";
+import { BadgeCheck, ChevronsUpDown, LogOut } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@board-games/ui/avatar";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -23,6 +25,7 @@ export function NavUser() {
   const { user } = useUser();
   const { isMobile } = useSidebar();
   if (!user) return null;
+
   return (
     <SidebarMenu>
       <SidebarMenuItem>
@@ -77,6 +80,19 @@ export function NavUser() {
                 </div>
               </div>
             </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                <Link
+                  href="/dashboard/user-profile"
+                  className="flex items-center gap-2"
+                >
+                  <BadgeCheck className="h-5 w-5" />
+                  Account
+                </Link>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
             <DropdownMenuSeparator />
             <DropdownMenuItem>
               <SignOutButton>

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -12,9 +12,9 @@
   },
   "aliases": {
     "components": "src/",
-    "utils": "@board-games/ui/utils",
+    "utils": "/lib/utils",
     "ui": "src/",
-    "lib": "@board-games/ui/lib",
+    "lib": "/lib",
     "hooks": "@board-games/ui/hooks"
   },
   "iconLibrary": "lucide"

--- a/packages/ui/src/alert.tsx
+++ b/packages/ui/src/alert.tsx
@@ -1,0 +1,60 @@
+import type { VariantProps } from "class-variance-authority";
+import * as React from "react";
+import { cva } from "class-variance-authority";
+
+import { cn } from "./lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

- Added `ProfilePage` and supporting components (`ProfileHeader`, `ProfileDetails`, `ProfileConnectedAccounts`, `ProfileSecurity`, `ProfileTabs`) for user profile management  
- Enabled `prefetch` on the NavUser profile link to improve navigation performance  
- Enhanced `AppSidebar` with a new `SidebarHeader` and a prefetching link to Board Games Tracker using the Dices icon  
- Introduced a new `Alert` component (with `AlertTitle` and `AlertDescription`) and updated component path aliases in `components.json`

---

## Screenshots

![image](https://github.com/user-attachments/assets/2d3479ce-363c-4663-883f-9635fa8c4382)
![image](https://github.com/user-attachments/assets/bc08dc46-7ae6-4e38-8a75-e833dbb1e9fa)
![image](https://github.com/user-attachments/assets/a5eeab67-9366-4220-9216-374d837018dc)
![image](https://github.com/user-attachments/assets/69da57fc-6e77-423b-b2a1-df0191555813)

