### PR TITLE
feat(sharing): introduce friend settings schema and refine share request logic

### DIFF
--- a/packages/api/src/routers/sharing/share-request.ts
+++ b/packages/api/src/routers/sharing/share-request.ts
@@ -440,6 +440,9 @@ export const shareRequestRouter = createTRPCRouter({
                         itemId: matchPlayer.player.id,
                         permission: "view",
                         parentShareId: newShare.id,
+                        status: friendSettings?.autoAcceptPlayers
+                          ? "accepted"
+                          : "pending",
                         expiresAt: input.expiresAt ?? null,
                       });
                       let returnedSharePlayer: z.infer<
@@ -509,6 +512,9 @@ export const shareRequestRouter = createTRPCRouter({
                   itemType: "scoresheet",
                   itemId: scoresheetToShare.scoresheetId,
                   permission: scoresheetToShare.permission,
+                  status: friendSettings?.autoAcceptGame
+                    ? "accepted"
+                    : "pending",
                   parentShareId: newShare.id,
                   expiresAt: input.expiresAt ?? null,
                 });

--- a/packages/api/src/routers/sharing/share-request.ts
+++ b/packages/api/src/routers/sharing/share-request.ts
@@ -786,7 +786,7 @@ export const shareRequestRouter = createTRPCRouter({
                   friendId: returnedFriend.id,
                 },
               });
-              const existingShare = await tx.query.shareRequest.findFirst({
+              const existingShare = await tx2.query.shareRequest.findFirst({
                 where: {
                   itemId: input.matchId,
                   itemType: "match",
@@ -820,7 +820,7 @@ export const shareRequestRouter = createTRPCRouter({
                 });
                 return false;
               }
-              const [newShare] = await tx
+              const [newShare] = await tx2
                 .insert(shareRequest)
                 .values({
                   ownerId: ctx.userId,
@@ -846,7 +846,7 @@ export const shareRequestRouter = createTRPCRouter({
 
               if (returnedMatch.locationId) {
                 const existingShareLocation =
-                  await ctx.db.query.shareRequest.findFirst({
+                  await tx2.query.shareRequest.findFirst({
                     where: {
                       OR: [
                         {
@@ -867,7 +867,7 @@ export const shareRequestRouter = createTRPCRouter({
                     },
                   });
                 if (!existingShareLocation) {
-                  await ctx.db.insert(shareRequest).values({
+                  await tx2.insert(shareRequest).values({
                     ownerId: ctx.userId,
                     sharedWithId: friendToShareTo.id,
                     itemType: "location",
@@ -910,7 +910,7 @@ export const shareRequestRouter = createTRPCRouter({
               }
 
               const returnedSharedGameRequest =
-                await tx.query.shareRequest.findFirst({
+                await tx2.query.shareRequest.findFirst({
                   where: {
                     itemId: returnedMatch.gameId,
                     itemType: "game",
@@ -924,7 +924,7 @@ export const shareRequestRouter = createTRPCRouter({
                 typeof selectSharedGameSchema
               > | null = null;
               if (!returnedSharedGameRequest) {
-                await tx.insert(shareRequest).values({
+                await tx2.insert(shareRequest).values({
                   ownerId: ctx.userId,
                   sharedWithId: friendToShareTo.id,
                   itemType: "game",
@@ -964,7 +964,7 @@ export const shareRequestRouter = createTRPCRouter({
                     returnedShareGame = createdSharedGame;
                   }
                 }
-                const gamesScoreSheets = await tx.query.scoresheet.findMany({
+                const gamesScoreSheets = await tx2.query.scoresheet.findMany({
                   where: {
                     gameId: returnedMatch.gameId,
                     userId: ctx.userId,
@@ -982,7 +982,7 @@ export const shareRequestRouter = createTRPCRouter({
                   (sheet) => sheet.type === "Default",
                 );
                 if (defaultScoreSheet) {
-                  await tx.insert(shareRequest).values({
+                  await tx2.insert(shareRequest).values({
                     ownerId: ctx.userId,
                     sharedWithId: null,
                     itemType: "scoresheet",
@@ -1024,7 +1024,7 @@ export const shareRequestRouter = createTRPCRouter({
                     }
                   }
                 } else if (gamesScoreSheets[0]) {
-                  await tx.insert(shareRequest).values({
+                  await tx2.insert(shareRequest).values({
                     ownerId: ctx.userId,
                     sharedWithId: null,
                     itemType: "scoresheet",
@@ -1110,7 +1110,7 @@ export const shareRequestRouter = createTRPCRouter({
               if (input.includePlayers) {
                 for (const matchPlayer of returnedMatch.matchPlayers) {
                   const existingSharedMatchPlayer =
-                    await tx.query.shareRequest.findFirst({
+                    await tx2.query.shareRequest.findFirst({
                       where: {
                         itemId: matchPlayer.playerId,
                         itemType: "player",
@@ -1120,7 +1120,7 @@ export const shareRequestRouter = createTRPCRouter({
                       },
                     });
                   if (!existingSharedMatchPlayer) {
-                    await tx.insert(shareRequest).values({
+                    await tx2.insert(shareRequest).values({
                       ownerId: ctx.userId,
                       sharedWithId: friendToShareTo.id,
                       itemType: "player",

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -203,6 +203,14 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.user.id,
       to: r.shareRequest.ownerId,
     }),
+    friendPlayers: r.many.friendPlayer({
+      from: r.user.id,
+      to: r.friendPlayer.createdById,
+    }),
+    friendSettings: r.one.friendSetting({
+      from: r.user.id,
+      to: r.friendSetting.createdById,
+    }),
   },
   group: {
     createdBy: r.one.user({
@@ -403,6 +411,10 @@ export const relations = defineRelations(schema, (r) => ({
           isNull: true,
         },
       },
+    }),
+    friendPlayer: r.one.friendPlayer({
+      from: r.player.id,
+      to: r.friendPlayer.playerId,
     }),
   },
   sharedPlayer: {
@@ -640,6 +652,14 @@ export const relations = defineRelations(schema, (r) => ({
       to: r.user.id,
       optional: false,
     }),
+    friendSetting: r.one.friendSetting({
+      from: r.friend.id,
+      to: r.friendSetting.friendId,
+    }),
+    friendPlayer: r.one.friendPlayer({
+      from: r.friend.id,
+      to: r.friendPlayer.friendId,
+    }),
   },
   friendRequest: {
     user: r.one.user({
@@ -650,6 +670,35 @@ export const relations = defineRelations(schema, (r) => ({
     requestee: r.one.user({
       from: r.friendRequest.requesteeId,
       to: r.user.id,
+      optional: false,
+    }),
+  },
+  friendSetting: {
+    createdBy: r.one.user({
+      from: r.friendSetting.createdById,
+      to: r.user.id,
+      optional: false,
+    }),
+    friend: r.one.friend({
+      from: r.friendSetting.friendId,
+      to: r.friend.id,
+      optional: false,
+    }),
+  },
+  friendPlayer: {
+    createdBy: r.one.user({
+      from: r.friendPlayer.createdById,
+      to: r.user.id,
+      optional: false,
+    }),
+    friend: r.one.friend({
+      from: r.friendPlayer.friendId,
+      to: r.friend.id,
+      optional: false,
+    }),
+    player: r.one.player({
+      from: r.friendPlayer.playerId,
+      to: r.player.id,
       optional: false,
     }),
   },

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -203,6 +203,10 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.user.id,
       to: r.shareRequest.ownerId,
     }),
+    friends: r.many.friend({
+      from: r.user.id,
+      to: r.friend.userId,
+    }),
     friendPlayers: r.many.friendPlayer({
       from: r.user.id,
       to: r.friendPlayer.createdById,

--- a/packages/db/src/schema/friendPlayer.ts
+++ b/packages/db/src/schema/friendPlayer.ts
@@ -1,0 +1,52 @@
+// schema/friendPlayer.ts
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  serial,
+  text,
+  timestamp,
+  unique,
+} from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import friend from "./friends";
+import player from "./player";
+import user from "./user";
+
+const friendPlayer = createTable(
+  "friend_player",
+  {
+    id: serial("id").primaryKey(),
+    createdById: integer("created_by_id")
+      .references(() => user.id)
+      .notNull(),
+    friendId: integer("friend_id")
+      .references(() => friend.id)
+      .notNull(),
+    playerId: integer("player_id")
+      .references(() => player.id)
+      .notNull(),
+    permission: text("permission", { enum: ["view", "edit"] })
+      .default("view")
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .default(sql`CURRENT_TIMESTAMP`)
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+      () => new Date(),
+    ),
+  },
+  (table) => [
+    index("boardgames_friend_player_created_by_id_index").on(table.createdById),
+    index("boardgames_friend_player_friend_id_index").on(table.friendId),
+    index("boardgames_friend_player_player_id_index").on(table.playerId),
+    index("boardgames_friend_player_id_index").on(table.id),
+    unique("boardgames_friend_player_unique").on(
+      table.friendId,
+      table.playerId,
+    ),
+  ],
+);
+
+export default friendPlayer;

--- a/packages/db/src/schema/friendSetting.ts
+++ b/packages/db/src/schema/friendSetting.ts
@@ -1,0 +1,85 @@
+import { sql } from "drizzle-orm";
+import {
+  boolean,
+  index,
+  integer,
+  serial,
+  text,
+  timestamp,
+  unique,
+} from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import friend from "./friends";
+import user from "./user";
+
+const friendSettings = createTable(
+  "friend_setting",
+  {
+    id: serial("id").primaryKey(),
+    createdById: integer("created_by_id")
+      .references(() => user.id)
+      .notNull(),
+    friendId: integer("friend_id")
+      .references(() => friend.id)
+      .notNull(),
+    autoShareMatches: boolean("share_matches").default(false).notNull(),
+    sharePlayersWithMatch: boolean("share_players").default(false).notNull(),
+    includeLocationWithMatch: boolean("include_location")
+      .default(false)
+      .notNull(),
+    defaultPermissionForMatches: text("default_permission_for_matches", {
+      enum: ["view", "edit"],
+    })
+      .default("view")
+      .notNull(),
+    defaultPermissionForPlayers: text("default_permission_for_players", {
+      enum: ["view", "edit"],
+    })
+      .default("view")
+      .notNull(),
+    defaultPermissionForLocation: text("default_permission_for_location", {
+      enum: ["view", "edit"],
+    })
+      .default("view")
+      .notNull(),
+    defaultPermissionForGame: text("default_permission_for_game", {
+      enum: ["view", "edit"],
+    })
+      .default("view")
+      .notNull(),
+    autoAcceptMatches: boolean("auto_accept_matches").default(false).notNull(),
+    autoAcceptPlayers: boolean("auto_accept_players").default(false).notNull(),
+    autoAcceptLocation: boolean("auto_accept_location")
+      .default(false)
+      .notNull(),
+    autoAcceptGame: boolean("auto_accept_game").default(false).notNull(),
+    allowSharedGames: boolean("allow_shared_games").default(false).notNull(),
+    allowSharedPlayers: boolean("allow_shared_players")
+      .default(false)
+      .notNull(),
+    allowSharedLocation: boolean("allow_shared_location")
+      .default(false)
+      .notNull(),
+    allowSharedMatches: boolean("allow_shared_matches")
+      .default(false)
+      .notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .default(sql`CURRENT_TIMESTAMP`)
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+      () => new Date(),
+    ),
+  },
+  (table) => [
+    index("boardgames_friend_settings_owner_id_index").on(table.createdById),
+    index("boardgames_friend_settings_friend_id_index").on(table.friendId),
+    index("boardgames_friend_settings_id_index").on(table.id),
+    unique("boardgames_friend_settings_unique").on(
+      table.createdById,
+      table.friendId,
+    ),
+  ],
+);
+
+export default friendSettings;

--- a/packages/db/src/schema/friendSetting.ts
+++ b/packages/db/src/schema/friendSetting.ts
@@ -54,16 +54,12 @@ const friendSettings = createTable(
       .default(false)
       .notNull(),
     autoAcceptGame: boolean("auto_accept_game").default(false).notNull(),
-    allowSharedGames: boolean("allow_shared_games").default(false).notNull(),
-    allowSharedPlayers: boolean("allow_shared_players")
-      .default(false)
-      .notNull(),
+    allowSharedGames: boolean("allow_shared_games").default(true).notNull(),
+    allowSharedPlayers: boolean("allow_shared_players").default(true).notNull(),
     allowSharedLocation: boolean("allow_shared_location")
-      .default(false)
+      .default(true)
       .notNull(),
-    allowSharedMatches: boolean("allow_shared_matches")
-      .default(false)
-      .notNull(),
+    allowSharedMatches: boolean("allow_shared_matches").default(true).notNull(),
     createdAt: timestamp("created_at", { withTimezone: true })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -21,3 +21,5 @@ export { default as shareRequest } from "./shareRequest";
 export { default as sharedScoresheet } from "./sharedScoresheet";
 export { default as sharedMatchPlayer } from "./sharedMatchPlayer";
 export { default as sharedLocation } from "./sharedLocation";
+export { default as friendPlayer } from "./friendPlayer";
+export { default as friendSetting } from "./friendSetting";


### PR DESCRIPTION
## ✅ Checklist

* [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
* [ ] I performed a functional test on my final commit

---

## Changelog
- Add new `friendSetting` and `friendPlayer` schemas to support per-friend sharing preferences  
- Update default values in the `friendSetting` schema to allow shared games, matches, players, and locations by default  
- Refine sharing logic to leverage friend settings for granular control over shared matches, locations, and players  
- Implement status handling on share requests (auto-accept vs. pending) based on friend preferences  
- Optimize share request handling by consolidating transaction management and standardizing error handling  
- Streamline share request creation to support multiple item types (games, matches, locations, players, scoresheets)  
- Prepare detailed database migrations and relationship updates to support the above changes  

