### PR TITLE
Add game roles and tags functionality

### DIFF
--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/CommentDialog.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/CommentDialog.tsx
@@ -20,7 +20,7 @@ import {
   FormMessage,
   useForm,
 } from "@board-games/ui/form";
-import { Input } from "@board-games/ui/input";
+import { Textarea } from "@board-games/ui/textarea";
 
 import { useTRPC } from "~/trpc/react";
 
@@ -104,7 +104,7 @@ function Content({
               <FormItem>
                 <FormLabel className="hidden">Comment:</FormLabel>
                 <FormControl>
-                  <Input {...field} />
+                  <Textarea {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/CommentDialog.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/CommentDialog.tsx
@@ -37,10 +37,10 @@ export function CommentDialog({
       <DialogTrigger asChild>
         <Button
           variant="ghost"
-          className="h-fit min-w-[50%] items-start justify-start"
+          className="h-fit min-h-12 min-w-[50%] max-w-full items-start justify-start"
         >
-          <span className="text-lg font-semibold text-primary">Comment:</span>
           <span className="text-wrap text-start text-base text-primary">
+            <b className="text-lg font-semibold text-primary">Comment:</b>
             {comment ?? "No comment"}
           </span>
         </Button>

--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/DetailDialog.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/DetailDialog.tsx
@@ -42,7 +42,7 @@ export function DetailDialog({
       <DialogTrigger asChild>
         <Button
           variant="ghost"
-          className="h-full w-full min-w-20 max-w-[] items-start justify-start p-0"
+          className="h-full w-full min-w-20 items-start justify-start p-0"
         >
           <p className="max-h-10 min-h-6 overflow-scroll whitespace-normal text-wrap break-words text-start text-base text-primary">
             {data.details ?? ""}

--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/DetailDialog.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/DetailDialog.tsx
@@ -42,11 +42,11 @@ export function DetailDialog({
       <DialogTrigger asChild>
         <Button
           variant="ghost"
-          className="h-full w-full min-w-20 items-start justify-start p-0"
+          className="h-full w-full min-w-20 max-w-[] items-start justify-start p-0"
         >
-          <span className="max-h-10 min-h-6 overflow-scroll text-wrap text-start text-base text-primary">
+          <p className="max-h-10 min-h-6 overflow-scroll whitespace-normal text-wrap break-words text-start text-base text-primary">
             {data.details ?? ""}
-          </span>
+          </p>
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/match.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/[matchId]/_components/match.tsx
@@ -437,7 +437,10 @@ export function Match({ matchId }: { matchId: number }) {
           )}
         </CardHeader>
         <Card>
-          <Table containerClassname="max-h-[65vh] h-fit w-screen sm:w-auto rounded-lg">
+          <Table
+            containerClassname="max-h-[65vh] h-fit w-screen sm:w-auto rounded-lg"
+            className="table-fixed"
+          >
             <>
               <TableHeader className="bg-sidebar sticky top-0 z-20 text-card-foreground shadow-lg">
                 <HeaderRow match={match} players={players} />

--- a/apps/nextjs/src/app/dashboard/games/[id]/edit/_components/editGameForm.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/edit/_components/editGameForm.tsx
@@ -296,6 +296,14 @@ const GameForm = ({
           trpc.game.getGame.queryOptions({ id: data.game.id }),
         );
         await queryClient.invalidateQueries(
+          trpc.game.getGameRoles.queryOptions({
+            gameId: data.game.id,
+          }),
+        );
+        await queryClient.invalidateQueries(
+          trpc.game.getEditGame.queryOptions({ id: data.game.id }),
+        );
+        await queryClient.invalidateQueries(
           trpc.game.getGameMetaData.queryOptions({ id: data.game.id }),
         );
         await queryClient.invalidateQueries(
@@ -365,10 +373,9 @@ const GameForm = ({
       playtimeMinChanged ||
       playtimeMaxChanged ||
       yearPublishedChanged ||
-      imageChanged ||
-      rolesChanged;
+      imageChanged;
 
-    if (gameChanged || scoresheetChanged) {
+    if (gameChanged || scoresheetChanged || rolesChanged) {
       const updatedRoles = values.roles
         .map((role) => {
           const originalRole = data.roles.find((r) => r.id === role.id);
@@ -385,6 +392,9 @@ const GameForm = ({
         })
         .filter((role) => role !== null);
       const newRoles = values.roles.filter((role) => role.id < 0);
+      const deletedRoles = data.roles
+        .filter((role) => !values.roles.find((vRole) => vRole.id === role.id))
+        .map((role) => role.id);
       const game = gameChanged
         ? {
             type: "updateGame" as const,
@@ -399,8 +409,6 @@ const GameForm = ({
               ? values.yearPublished
               : undefined,
             image: image,
-            updatedRoles: updatedRoles,
-            newRoles: newRoles,
           }
         : { type: "default" as const, id: data.game.id };
       if (scoresheetChanged) {
@@ -598,12 +606,18 @@ const GameForm = ({
           game: game,
           scoresheets: changedScoresheets,
           scoresheetsToDelete: scoresheetsToDelete,
+          updatedRoles: updatedRoles,
+          newRoles: newRoles,
+          deletedRoles: deletedRoles,
         });
       } else {
         mutation.mutate({
           game: game,
           scoresheets: [],
           scoresheetsToDelete: [],
+          updatedRoles: updatedRoles,
+          newRoles: newRoles,
+          deletedRoles: deletedRoles,
         });
       }
     }

--- a/apps/nextjs/src/app/dashboard/games/[id]/edit/_components/editGameForm.tsx
+++ b/apps/nextjs/src/app/dashboard/games/[id]/edit/_components/editGameForm.tsx
@@ -9,6 +9,7 @@ import {
   Copy,
   Minus,
   Plus,
+  SquarePen,
   Table,
   Trash,
   Trash2,
@@ -1193,32 +1194,19 @@ const GameForm = ({
                                   <Button
                                     type="button"
                                     variant="ghost"
-                                    size="sm"
+                                    size="icon"
                                     onClick={() =>
                                       setEditGameRoleIndex(roleIndex)
                                     }
-                                    className="h-8 w-8 p-0 text-gray-400 hover:text-white"
                                   >
-                                    <svg
-                                      className="h-4 w-4"
-                                      fill="none"
-                                      stroke="currentColor"
-                                      viewBox="0 0 24 24"
-                                    >
-                                      <path
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth={2}
-                                        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                                      />
-                                    </svg>
+                                    <SquarePen className="h-4 w-4" />
                                   </Button>
                                   <Button
                                     type="button"
                                     variant="ghost"
-                                    size="sm"
+                                    size="icon"
                                     onClick={() => removeRole(roleIndex)}
-                                    className="h-8 w-8 p-0 text-red-400 hover:bg-red-900/20 hover:text-red-300"
+                                    className="text-destructive hover:text-destructive"
                                   >
                                     <Trash2 className="h-4 w-4" />
                                   </Button>

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -451,6 +451,21 @@ export const gameRouter = createTRPCRouter({
       ];
       return mappedScoresheets;
     }),
+  getGameRoles: protectedUserProcedure
+    .input(z.object({ gameId: z.number() }))
+    .query(async ({ ctx, input }) => {
+      const result = await ctx.db.query.gameRole.findMany({
+        where: {
+          gameId: input.gameId,
+        },
+        columns: {
+          id: true,
+          name: true,
+          description: true,
+        },
+      });
+      return result;
+    }),
   getEditGame: protectedUserProcedure
     .input(selectGameSchema.pick({ id: true }))
     .query(async ({ ctx, input }) => {
@@ -638,6 +653,7 @@ export const gameRouter = createTRPCRouter({
                   },
                   team: true,
                   playerRounds: true,
+                  roles: true,
                 },
               },
               location: true,
@@ -674,6 +690,7 @@ export const gameRouter = createTRPCRouter({
                     with: {
                       team: true,
                       playerRounds: true,
+                      roles: true,
                     },
                   },
                   sharedPlayer: {
@@ -738,9 +755,71 @@ export const gameRouter = createTRPCRouter({
               },
             },
           },
+          roles: true,
         },
       });
       if (!result) return null;
+      const roleStats = result.roles.reduce(
+        (acc, role) => {
+          acc[role.id] = {
+            roleId: role.id,
+            name: role.name,
+            description: role.description,
+            playerCount: 0,
+            matchCount: 0,
+            winRate: 0,
+            wins: 0,
+            placements: {},
+            players: {},
+          };
+          return acc;
+        },
+        {} as Record<
+          number,
+          {
+            roleId: number;
+            name: string;
+            description: string | null;
+            playerCount: number;
+            matchCount: number;
+            winRate: number;
+            wins: number;
+            placements: Record<number, number>;
+            players: Record<
+              number,
+              {
+                id: number;
+                name: string;
+                isUser: boolean;
+                image: {
+                  name: string;
+                  url: string | null;
+                  type: "file" | "svg";
+                  usageType: "player" | "match" | "game";
+                } | null;
+                totalMatches: number;
+                totalWins: number;
+                winRate: number;
+                placements: Record<number, number>;
+              }
+            >;
+          }
+        >,
+      );
+      const comboRoles: Record<
+        string,
+        {
+          roles: {
+            id: number;
+            name: string;
+            description: string | null;
+          }[];
+          matchCount: number;
+          wins: number;
+          winRate: number;
+          placements: Record<number, number>;
+        }
+      > = {};
       const matches: {
         type: "original" | "shared";
         id: number;
@@ -799,6 +878,11 @@ export const gameRouter = createTRPCRouter({
             id: number;
             roundId: number;
             score: number | null;
+          }[];
+          roles: {
+            id: number;
+            name: string;
+            description: string | null;
           }[];
         }[];
         winners: {
@@ -868,6 +952,11 @@ export const gameRouter = createTRPCRouter({
                 id: round.id,
                 roundId: round.roundId,
                 score: round.score,
+              })),
+              roles: player.roles.map((role) => ({
+                id: role.id,
+                name: role.name,
+                description: role.description,
               })),
             };
           }),
@@ -969,6 +1058,13 @@ export const gameRouter = createTRPCRouter({
                       score: round.score,
                     }),
                   ),
+                roles: returnedSharedMatchPlayer.matchPlayer.roles.map(
+                  (role) => ({
+                    id: role.id,
+                    name: role.name,
+                    description: role.description,
+                  }),
+                ),
               };
             })
             .filter((player) => player !== null),
@@ -1059,6 +1155,67 @@ export const gameRouter = createTRPCRouter({
           const isCoop = currentScoresheet.isCoop;
           match.players.forEach((player) => {
             const accPlayer = acc[`${player.type}-${player.id}`];
+            player.roles.forEach((role) => {
+              const accRole = roleStats[role.id];
+              if (!accRole) {
+                roleStats[role.id] = {
+                  roleId: role.id,
+                  name: role.name,
+                  description: role.description,
+                  playerCount: 1,
+                  placements:
+                    player.placement > 0 ? { [player.placement]: 1 } : {},
+                  wins: player.isWinner ? 1 : 0,
+                  matchCount: 1,
+                  winRate: player.isWinner ? 1 : 0,
+                  players: {
+                    [player.id]: {
+                      id: player.id,
+                      name: player.name,
+                      isUser: player.isUser,
+                      image: player.image,
+                      totalMatches: 1,
+                      totalWins: player.isWinner ? 1 : 0,
+                      winRate: player.isWinner ? 1 : 0,
+                      placements:
+                        player.placement > 0 ? { [player.placement]: 1 } : {},
+                    },
+                  },
+                };
+              } else {
+                accRole.playerCount++;
+                if (player.placement > 0) {
+                  accRole.placements[player.placement] =
+                    (accRole.placements[player.placement] ?? 0) + 1;
+                }
+                accRole.wins += player.isWinner ? 1 : 0;
+                accRole.matchCount++;
+                accRole.winRate = accRole.wins / accRole.matchCount;
+                const accPlayer = accRole.players[player.id];
+                if (!accPlayer) {
+                  accRole.players[player.id] = {
+                    id: player.id,
+                    name: player.name,
+                    isUser: player.isUser,
+                    image: player.image,
+                    totalMatches: 1,
+                    totalWins: player.isWinner ? 1 : 0,
+                    winRate: player.isWinner ? 1 : 0,
+                    placements:
+                      player.placement > 0 ? { [player.placement]: 1 } : {},
+                  };
+                } else {
+                  accPlayer.totalMatches++;
+                  accPlayer.totalWins += player.isWinner ? 1 : 0;
+                  accPlayer.winRate =
+                    accPlayer.totalWins / accPlayer.totalMatches;
+                  if (player.placement > 0) {
+                    accPlayer.placements[player.placement] =
+                      (accPlayer.placements[player.placement] ?? 0) + 1;
+                  }
+                }
+              }
+            });
             if (!accPlayer) {
               const tempPlacements: Record<number, number> = {};
               const tempPlayerCount: Record<
@@ -1100,6 +1257,48 @@ export const gameRouter = createTRPCRouter({
                   >;
                 }
               > = {};
+              const tempRoleCombos: Record<
+                string,
+                {
+                  roles: {
+                    id: number;
+                    name: string;
+                    description: string | null;
+                  }[];
+                  matchCount: number;
+                  wins: number;
+                  winRate: number;
+                  placements: Record<number, number>;
+                }
+              > = {};
+              if (player.roles.length >= 2) {
+                const sortedRoles = player.roles.map((r) => r.name).sort();
+                const roleComboKey = sortedRoles.join(" + ");
+                const accRoleCombo = tempRoleCombos[roleComboKey];
+                if (!accRoleCombo) {
+                  tempRoleCombos[roleComboKey] = {
+                    roles: player.roles.map((r) => ({
+                      id: r.id,
+                      name: r.name,
+                      description: r.description,
+                    })),
+                    matchCount: 1,
+                    wins: player.isWinner ? 1 : 0,
+                    winRate: player.isWinner ? 1 : 0,
+                    placements:
+                      player.placement > 0 ? { [player.placement]: 1 } : {},
+                  };
+                } else {
+                  accRoleCombo.matchCount++;
+                  accRoleCombo.wins += player.isWinner ? 1 : 0;
+                  accRoleCombo.winRate =
+                    accRoleCombo.wins / accRoleCombo.matchCount;
+                  if (player.placement > 0) {
+                    accRoleCombo.placements[player.placement] =
+                      (accRoleCombo.placements[player.placement] ?? 0) + 1;
+                  }
+                }
+              }
               if (!isCoop) {
                 tempPlacements[player.placement] = 1;
                 tempPlayerCount[match.players.length] = {
@@ -1181,10 +1380,115 @@ export const gameRouter = createTRPCRouter({
                 recentForm: player.isWinner ? ["win"] : ["loss"],
                 playerCount: !isCoop ? tempPlayerCount : {},
                 scoresheets: tempScoresheets,
+                roles: player.roles.reduce(
+                  (acc, role) => {
+                    acc[role.id] = {
+                      roleId: role.id,
+                      name: role.name,
+                      description: role.description,
+                      matchCount: 1,
+                      winRate: player.isWinner ? 1 : 0,
+                      wins: player.isWinner ? 1 : 0,
+                      placements:
+                        player.placement > 0 ? { [player.placement]: 1 } : {},
+                    };
+                    return acc;
+                  },
+                  {} as Record<
+                    number,
+                    {
+                      roleId: number;
+                      name: string;
+                      description: string | null;
+                      matchCount: number;
+                      winRate: number;
+                      wins: number;
+                      placements: Record<number, number>;
+                    }
+                  >,
+                ),
+                roleCombos: tempRoleCombos,
               };
             } else {
               accPlayer.recentForm.push(player.isWinner ? "win" : "loss");
               const current = accPlayer.streaks.current;
+              player.roles.forEach((role) => {
+                const accRole = accPlayer.roles[role.id];
+                if (!accRole) {
+                  accPlayer.roles[role.id] = {
+                    roleId: role.id,
+                    name: role.name,
+                    description: role.description,
+                    matchCount: 1,
+                    winRate: player.isWinner ? 1 : 0,
+                    wins: player.isWinner ? 1 : 0,
+                    placements:
+                      player.placement > 0 ? { [player.placement]: 1 } : {},
+                  };
+                } else {
+                  accRole.matchCount++;
+                  accRole.winRate =
+                    (accRole.wins + (player.isWinner ? 1 : 0)) /
+                    accRole.matchCount;
+                  accRole.wins += player.isWinner ? 1 : 0;
+                  if (player.placement > 0) {
+                    accRole.placements[player.placement] =
+                      (accRole.placements[player.placement] ?? 0) + 1;
+                  }
+                }
+              });
+              if (player.roles.length >= 2) {
+                const sortedRoles = player.roles.map((r) => r.name).sort();
+                const roleComboKey = sortedRoles.join(" + ");
+                const accRoleCombo = comboRoles[roleComboKey];
+                if (!accRoleCombo) {
+                  comboRoles[roleComboKey] = {
+                    roles: player.roles.map((r) => ({
+                      id: r.id,
+                      name: r.name,
+                      description: r.description,
+                    })),
+                    matchCount: 1,
+                    wins: player.isWinner ? 1 : 0,
+                    winRate: player.isWinner ? 1 : 0,
+                    placements:
+                      player.placement > 0 ? { [player.placement]: 1 } : {},
+                  };
+                } else {
+                  accRoleCombo.matchCount++;
+                  accRoleCombo.wins += player.isWinner ? 1 : 0;
+                  accRoleCombo.winRate =
+                    accRoleCombo.wins / accRoleCombo.matchCount;
+                  if (player.placement > 0) {
+                    accRoleCombo.placements[player.placement] =
+                      (accRoleCombo.placements[player.placement] ?? 0) + 1;
+                  }
+                }
+                const playerCombo = accPlayer.roleCombos[roleComboKey];
+                if (!playerCombo) {
+                  accPlayer.roleCombos[roleComboKey] = {
+                    roles: player.roles.map((r) => ({
+                      id: r.id,
+                      name: r.name,
+                      description: r.description,
+                    })),
+                    matchCount: 1,
+                    wins: player.isWinner ? 1 : 0,
+                    winRate: player.isWinner ? 1 : 0,
+                    placements:
+                      player.placement > 0 ? { [player.placement]: 1 } : {},
+                  };
+                } else {
+                  playerCombo.matchCount++;
+                  playerCombo.wins += player.isWinner ? 1 : 0;
+                  playerCombo.winRate =
+                    playerCombo.wins / playerCombo.matchCount;
+                  if (player.placement > 0) {
+                    playerCombo.placements[player.placement] =
+                      (playerCombo.placements[player.placement] ?? 0) + 1;
+                  }
+                }
+              }
               if (
                 (player.isWinner && current.type === "win") ||
                 (!player.isWinner && current.type === "loss")
@@ -1438,6 +1742,32 @@ export const gameRouter = createTRPCRouter({
                 >;
               }
             >;
+            roles: Record<
+              number,
+              {
+                roleId: number;
+                name: string;
+                description: string | null;
+                matchCount: number;
+                winRate: number;
+                wins: number;
+                placements: Record<number, number>;
+              }
+            >;
+            roleCombos: Record<
+              string,
+              {
+                roles: {
+                  id: number;
+                  name: string;
+                  description: string | null;
+                }[];
+                matchCount: number;
+                wins: number;
+                winRate: number;
+                placements: Record<number, number>;
+              }
+            >;
           }
         >,
       );
@@ -1504,12 +1834,29 @@ export const gameRouter = createTRPCRouter({
                 scoresheet.plays > 0 ? scoresheet.wins / scoresheet.plays : 0,
             };
           }),
+          roles: Object.values(player.roles).map((role) => ({
+            ...role,
+            winRate: role.wins / role.matchCount,
+          })),
+          roleCombos: Object.values(player.roleCombos).map((combo) => ({
+            ...combo,
+            winRate: combo.wins / combo.matchCount,
+          })),
         })),
         winRate: userWinRate,
         totalMatches: totalMatches,
         wonMatches: wonMatches,
         scoresheets: gameScoresheets,
         headToHead: headToHeadStats(matches),
+        roleStats: Object.values(roleStats).map((role) => ({
+          ...role,
+          winRate: role.wins / role.matchCount,
+          players: Object.values(role.players),
+        })),
+        roleCombos: Object.values(comboRoles).map((combo) => ({
+          ...combo,
+          winRate: combo.wins / combo.matchCount,
+        })),
       };
     }),
   getGameName: protectedUserProcedure

--- a/packages/api/src/routers/game.ts
+++ b/packages/api/src/routers/game.ts
@@ -522,7 +522,13 @@ export const gameRouter = createTRPCRouter({
               },
             },
           },
-          roles: true,
+          roles: {
+            where: {
+              deletedAt: {
+                isNull: true,
+              },
+            },
+          },
         },
       });
       if (!result) return null;
@@ -762,7 +768,13 @@ export const gameRouter = createTRPCRouter({
               },
             },
           },
-          roles: true,
+          roles: {
+            where: {
+              deletedAt: {
+                isNull: true,
+              },
+            },
+          },
         },
       });
       if (!result) return null;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -33,7 +33,7 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "lint": "eslint",
     "push": "pnpm with-env drizzle-kit push",
-    "seed": "tsx src/seeding/seed.ts",
+    "seed": "pnpm with-env tsx src/seeding/seed.ts",
     "studio": "pnpm with-env drizzle-kit studio",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false",
     "with-env": "dotenv -e ../../.env --"

--- a/packages/db/src/relations/index.ts
+++ b/packages/db/src/relations/index.ts
@@ -4,6 +4,10 @@ import * as schema from "../schema";
 
 export const relations = defineRelations(schema, (r) => ({
   matchPlayer: {
+    roles: r.many.gameRole({
+      from: r.matchPlayer.id.through(r.matchPlayerRole.matchPlayerId),
+      to: r.gameRole.id.through(r.matchPlayerRole.roleId),
+    }),
     rounds: r.many.round({
       from: r.matchPlayer.id.through(r.roundPlayer.matchPlayerId),
       to: r.round.id.through(r.roundPlayer.roundId),
@@ -318,6 +322,10 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.game.id.through(r.sharedGame.linkedGameId),
       to: r.sharedMatch.sharedGameId.through(r.sharedGame.id),
     }),
+    roles: r.many.gameRole({
+      from: r.game.id,
+      to: r.gameRole.gameId,
+    }),
     scoresheets: r.many.scoresheet({
       from: r.game.id,
       to: r.scoresheet.gameId,
@@ -327,6 +335,10 @@ export const relations = defineRelations(schema, (r) => ({
           isNull: true,
         },
       },
+    }),
+    tags: r.many.tag({
+      from: r.game.id.through(r.gameTag.gameId),
+      to: r.tag.id.through(r.gameTag.tagId),
     }),
   },
   location: {
@@ -717,6 +729,28 @@ export const relations = defineRelations(schema, (r) => ({
       from: r.matchImage.imageId,
       to: r.image.id,
       optional: false,
+    }),
+  },
+  tag: {
+    createdBy: r.one.user({
+      from: r.tag.createdBy,
+      to: r.user.id,
+      optional: false,
+    }),
+    games: r.many.game({
+      from: r.tag.id.through(r.gameTag.tagId),
+      to: r.game.id.through(r.gameTag.gameId),
+    }),
+  },
+  gameRole: {
+    game: r.one.game({
+      from: r.gameRole.gameId,
+      to: r.game.id,
+      optional: false,
+    }),
+    matchPlayers: r.many.matchPlayer({
+      from: r.gameRole.id.through(r.matchPlayerRole.roleId),
+      to: r.matchPlayer.id.through(r.matchPlayerRole.matchPlayerId),
     }),
   },
 }));

--- a/packages/db/src/schema/gameRole.ts
+++ b/packages/db/src/schema/gameRole.ts
@@ -21,6 +21,7 @@ const gameRoles = createTable("game_role", {
   updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
     () => new Date(),
   ),
+  deletedAt: timestamp("deleted_at", { withTimezone: true }),
 });
 
 export default gameRoles;

--- a/packages/db/src/schema/gameRole.ts
+++ b/packages/db/src/schema/gameRole.ts
@@ -1,0 +1,22 @@
+import { sql } from "drizzle-orm";
+import { integer, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import game from "./game";
+
+const gameRoles = createTable("game_role", {
+  id: serial("id").primaryKey(),
+  name: varchar("name", { length: 100 }).notNull(),
+  description: text("description"),
+  gameId: integer("game_id")
+    .notNull()
+    .references(() => game.id),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+    () => new Date(),
+  ),
+});
+
+export default gameRoles;

--- a/packages/db/src/schema/gameRole.ts
+++ b/packages/db/src/schema/gameRole.ts
@@ -3,6 +3,7 @@ import { integer, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
 
 import { createTable } from "./baseTable";
 import game from "./game";
+import user from "./user";
 
 const gameRoles = createTable("game_role", {
   id: serial("id").primaryKey(),
@@ -11,6 +12,9 @@ const gameRoles = createTable("game_role", {
   gameId: integer("game_id")
     .notNull()
     .references(() => game.id),
+  createdBy: integer("created_by")
+    .notNull()
+    .references(() => user.id),
   createdAt: timestamp("created_at", { withTimezone: true })
     .default(sql`CURRENT_TIMESTAMP`)
     .notNull(),

--- a/packages/db/src/schema/gameTag.ts
+++ b/packages/db/src/schema/gameTag.ts
@@ -1,0 +1,24 @@
+import { integer, primaryKey } from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import game from "./game";
+import tag from "./tag";
+
+const gameTags = createTable(
+  "game_tag",
+  {
+    gameId: integer("game_id")
+      .notNull()
+      .references(() => game.id),
+    tagId: integer("tag_id")
+      .notNull()
+      .references(() => tag.id),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.gameId, table.tagId],
+    }),
+  ],
+);
+
+export default gameTags;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -23,3 +23,7 @@ export { default as sharedMatchPlayer } from "./sharedMatchPlayer";
 export { default as sharedLocation } from "./sharedLocation";
 export { default as friendSetting } from "./friendSetting";
 export { default as matchImage } from "./matchImage";
+export { default as gameTag } from "./gameTag";
+export { default as tag } from "./tag";
+export { default as gameRole } from "./gameRole";
+export { default as matchPlayerRole } from "./matchPlayerRole";

--- a/packages/db/src/schema/matchPlayerRole.ts
+++ b/packages/db/src/schema/matchPlayerRole.ts
@@ -1,0 +1,24 @@
+import { integer, primaryKey } from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import gameRole from "./gameRole";
+import matchPlayer from "./matchPlayer";
+
+const matchPlayerRoles = createTable(
+  "match_player_role",
+  {
+    matchPlayerId: integer("match_player_id")
+      .notNull()
+      .references(() => matchPlayer.id),
+    roleId: integer("role_id")
+      .notNull()
+      .references(() => gameRole.id),
+  },
+  (table) => [
+    primaryKey({
+      columns: [table.matchPlayerId, table.roleId],
+    }),
+  ],
+);
+
+export default matchPlayerRoles;

--- a/packages/db/src/schema/tag.ts
+++ b/packages/db/src/schema/tag.ts
@@ -1,0 +1,21 @@
+import { sql } from "drizzle-orm";
+import { integer, serial, timestamp, varchar } from "drizzle-orm/pg-core";
+
+import { createTable } from "./baseTable";
+import user from "./user";
+
+const tags = createTable("tag", {
+  id: serial("id").primaryKey(),
+  name: varchar("name", { length: 100 }).notNull(),
+  createdBy: integer("created_by")
+    .references(() => user.id)
+    .notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+    () => new Date(),
+  ),
+});
+
+export default tags;

--- a/packages/db/src/seeding/game-seeding.ts
+++ b/packages/db/src/seeding/game-seeding.ts
@@ -127,6 +127,7 @@ export async function seedGames(d3Seed: number) {
       );
       return selectedRoles.map((roleName) => ({
         gameId: game.id,
+        createdBy: user.id,
         name: roleName,
         description: faker.lorem.paragraph(),
       }));

--- a/packages/db/src/seeding/game-seeding.ts
+++ b/packages/db/src/seeding/game-seeding.ts
@@ -4,13 +4,16 @@ import { randomLcg, randomLogNormal } from "d3";
 
 import type { insertGameSchema } from "@board-games/db/zodSchema";
 import { db } from "@board-games/db/client";
-import { game, image } from "@board-games/db/schema";
+import { game, gameRole, gameTag, image, tag } from "@board-games/db/schema";
 
 import { resetTable } from "./seed";
 
 export async function seedGames(d3Seed: number) {
   faker.seed(d3Seed);
   await resetTable(game);
+  await resetTable(tag);
+  await resetTable(gameTag);
+  await resetTable(gameRole);
   const users = await db.query.user.findMany();
   const normalGames = randomLogNormal.source(randomLcg(d3Seed))(2, 0.7);
   const gameNames = Array.from({ length: 100 }, () =>
@@ -18,6 +21,19 @@ export async function seedGames(d3Seed: number) {
   );
   console.log("Inserting games...\n");
   for (const user of users) {
+    const tagCount = faker.number.int({ min: 5, max: 10 });
+    const tagNames = Array.from({ length: tagCount }, () =>
+      faker.commerce.productAdjective(),
+    );
+    const insertedTags = await db
+      .insert(tag)
+      .values(
+        tagNames.map((name) => ({
+          name,
+          createdBy: user.id,
+        })),
+      )
+      .returning();
     const gameCount = Math.max(8, normalGames() + 5);
     const gameData: z.infer<typeof insertGameSchema>[] = [];
     const usedNames = new Set<string>();
@@ -84,6 +100,42 @@ export async function seedGames(d3Seed: number) {
         }),
       });
     }
-    await db.insert(game).values(gameData);
+    const insertedGames = await db.insert(game).values(gameData).returning();
+
+    const gameTagData = insertedGames.flatMap((game) => {
+      const hasTags = faker.datatype.boolean(0.5);
+      if (!hasTags) {
+        return [];
+      }
+      // Select a random number of tags for the game
+      const tagCount = faker.number.int({ min: 1, max: 3 });
+      const selectedTags = faker.helpers.arrayElements(insertedTags, tagCount);
+      return selectedTags.map((t) => ({
+        gameId: game.id,
+        tagId: t.id,
+      }));
+    });
+    const gameRoleData = insertedGames.flatMap((game) => {
+      const hasRoles = faker.datatype.boolean(0.5);
+      if (!hasRoles) {
+        return [];
+      }
+      // Select a random number of roles for the game
+      const roleCount = faker.number.int({ min: 2, max: 6 });
+      const selectedRoles = Array.from({ length: roleCount }, () =>
+        faker.person.jobTitle(),
+      );
+      return selectedRoles.map((roleName) => ({
+        gameId: game.id,
+        name: roleName,
+        description: faker.lorem.paragraph(),
+      }));
+    });
+    if (gameRoleData.length > 0) {
+      await db.insert(gameRole).values(gameRoleData).returning();
+    }
+    if (gameTagData.length > 0) {
+      await db.insert(gameTag).values(gameTagData).returning();
+    }
   }
 }

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -109,6 +109,15 @@ export const editGameSchema = baseGameSchema.omit({ gameImg: true }).extend({
       }),
     ])
     .nullable(),
+  roles: z.array(
+    z.object({
+      id: z.number(),
+      name: z.string().min(1, {
+        message: "Role name is required",
+      }),
+      description: z.string().nullable(),
+    }),
+  ),
 });
 export const sharedEditGameSchema = baseGameSchema.omit({
   gameImg: true,


### PR DESCRIPTION
Introduce a schema for game roles and tags, enhance seeding logic to include these roles and tags, and implement role management in match creation and game editing. Update the UI to support these features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining, editing, and managing roles within games.
  * Enhanced match creation and editing flows to allow assigning multiple roles to players with a searchable, interactive UI.
  * Game statistics now include detailed analytics based on player roles and role combinations.
  * Introduced tagging system for games with tag management and associations.

* **Bug Fixes**
  * Improved form handling to ensure roles are properly submitted and tracked alongside players and teams.

* **Chores**
  * Updated database structure and seeding to support roles and tags for games and matches.
  * Seed data now includes roles and tags for games and assigns roles to match players.
  * Modified seeding scripts to insert role assignments for match players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->