### PR TITLE
Add user-scoped scoresheet analytics families

### DIFF
--- a/apps/web/src/components/game/stats/scoresheets/scoresheets-stats.tsx
+++ b/apps/web/src/components/game/stats/scoresheets/scoresheets-stats.tsx
@@ -142,6 +142,16 @@ export function ScoreSheetsStats({ game }: { game: GameInput }) {
                 </div>
               </div>
               <div>
+                <span className="text-muted-foreground">Analytics Family:</span>
+                <div className="font-semibold">
+                  {currentScoresheet.linkageState === "original"
+                    ? "Original"
+                    : currentScoresheet.linkageState === "shared_linked"
+                      ? "Linked shared"
+                      : "Unlinked shared"}
+                </div>
+              </div>
+              <div>
                 <span className="text-muted-foreground">Mode:</span>
                 <div className="font-semibold">
                   {currentScoresheet.isCoop ? "Co-operative" : "Competitive"}
@@ -159,7 +169,42 @@ export function ScoreSheetsStats({ game }: { game: GameInput }) {
                   {currentScoresheet.rounds.length}
                 </div>
               </div>
+              <div>
+                <span className="text-muted-foreground">
+                  Contributing Sheets:
+                </span>
+                <div className="font-semibold">
+                  {currentScoresheet.contributingVisibleScoresheets.length}
+                </div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">
+                  Contributing Matches:
+                </span>
+                <div className="font-semibold">
+                  {currentScoresheet.contributingMatchCount}
+                </div>
+              </div>
             </div>
+            {currentScoresheet.contributingVisibleScoresheets.length > 0 && (
+              <div className="border-t pt-2">
+                <span className="text-muted-foreground text-sm">
+                  Visible scoresheets in this family:
+                </span>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {currentScoresheet.contributingVisibleScoresheets.map(
+                    (scoresheet) => (
+                      <Badge
+                        key={`${scoresheet.visibleScoresheetSourceType}-${scoresheet.visibleScoresheetId}`}
+                        variant="outline"
+                      >
+                        {scoresheet.name} · {scoresheet.matchCount}
+                      </Badge>
+                    ),
+                  )}
+                </div>
+              </div>
+            )}
             {currentScoresheet.winCondition === "Target Score" && (
               <div className="border-t pt-2">
                 <span className="text-muted-foreground text-sm">

--- a/apps/web/src/hooks/game-stats/use-scoresheet-stats.tsx
+++ b/apps/web/src/hooks/game-stats/use-scoresheet-stats.tsx
@@ -18,7 +18,7 @@ type SortField =
 type SortOrder = "asc" | "desc";
 
 function getScoresheetKey(s: ScoresheetStatsItem): string {
-  return `${s.type}-${s.type === "original" ? s.id : s.sharedId}`;
+  return s.analyticsGroupingKey;
 }
 
 export function getCurrentPlayerKey(player: OverallPlayer): string {

--- a/docs/scoresheet-analytics-and-lifecycle.md
+++ b/docs/scoresheet-analytics-and-lifecycle.md
@@ -1,0 +1,145 @@
+# Scoresheet Analytics And Lifecycle
+
+## Why scoresheet analytics are user-scoped
+
+Scoresheet analytics are not globally canonical in this app. A shared scoresheet or shared match can mean different things to different recipients:
+
+- one user may merge it into their local Cascadia family
+- another user may keep it separate as an imported shared family
+- round mappings may differ per recipient even when the shared match is the same
+
+Because of that, analytics grouping is resolved per visible user, not from a single global root.
+
+## Storage lineage vs analytics grouping
+
+There are two separate concerns:
+
+- Storage lineage tracks where data came from and how it was copied or forked.
+- Analytics grouping decides which visible scoresheets and rounds count together for one user.
+
+Storage lineage uses:
+
+- `scoresheet.forkedFromScoresheetId`
+- `scoresheet.forkedFromSharedScoresheetId`
+- `round.parentId`
+- `round.templateRoundId`
+
+Analytics grouping uses:
+
+- `shared_scoresheet.analytics_linked_scoresheet_id`
+- `shared_round.analytics_linked_round_id`
+- the user-scoped analytics views
+
+Lineage answers “where did this come from?”
+
+Analytics grouping answers “what should count together for this user?”
+
+## How game, sharedGame, scoresheet, sharedScoresheet, match, and sharedMatch relate
+
+- `game` is the user-owned local game.
+- `shared_game` is the recipient-visible wrapper for someone else’s game.
+- `scoresheet` stores both local game/original sheets and match forks.
+- `shared_scoresheet` stores the recipient-visible wrapper for shared game sheets and shared match sheets.
+- `match` stores the real match and always points at a local match scoresheet fork.
+- `shared_match` exposes that match to a recipient and points at the recipient-visible shared match scoresheet.
+
+For shared matches, the shared match scoresheet has `parentId` pointing to the shared game-level scoresheet. Analytics resolution uses the game-level shared scoresheet family, not each shared match scoresheet independently.
+
+## Lifecycle: original game -> original scoresheet -> match fork
+
+For a normal local flow:
+
+1. A user owns a `game`.
+2. The game has local/original `scoresheet` rows with type `Game` or `Default`.
+3. Creating a match forks one of those into a `scoresheet` row with type `Match`.
+4. Analytics group the match back under the nearest non-match local scoresheet root.
+
+This family resolves as `linkageState = original`.
+
+## Lifecycle: shared game -> shared scoresheet -> local original copy -> match fork
+
+For shared content:
+
+1. A recipient sees a `shared_game`.
+2. The recipient sees a game-level `shared_scoresheet`.
+3. On first match creation from that shared scoresheet, the app creates a new local/original `scoresheet` copy in the recipient’s local game.
+4. The new local copy stores `forkedFromSharedScoresheetId`.
+5. Shared rounds are copied into local rounds.
+6. The shared scoresheet analytics link is set to that new local scoresheet.
+7. Shared round analytics links are set to the copied local rounds.
+8. The actual match scoresheet is then forked from that local/original copy.
+
+This matches the product rule: first local use adopts the shared scoresheet into the recipient’s world.
+
+## How shared scoresheet linking affects analytics
+
+Scoresheet analytics resolution works like this:
+
+- local/original family: group by the nearest non-match local scoresheet root
+- shared and unlinked: group by `shared_scoresheet.id`
+- shared and linked: group by `shared_scoresheet.analytics_linked_scoresheet_id`
+- local materialized from shared: resolve through `forkedFromSharedScoresheetId`
+
+That means two users can see the same shared match but group it differently.
+
+## How round linking affects analytics
+
+Round analytics are resolved separately from scoresheet analytics.
+
+- local/original round family: nearest non-match local root round
+- shared and unlinked: group by `shared_round.id`
+- shared and linked: group by `shared_round.analytics_linked_round_id`
+
+Round mappings are never inferred from round name, order, or `roundKey` alone.
+
+Partial round linking is allowed. A shared scoresheet can be linked at the scoresheet level while some rounds still remain separate shared round families.
+
+## What current stats endpoints now mean
+
+The existing stats endpoints were retrofitted instead of duplicated:
+
+- `getGameStatsHeader` now aggregates from user-visible analytics rows
+- `getGamePlayerStats` now includes shared matches only when visible to the current user
+- `getGameScoresheetStats` now returns analytics families, keyed by `analyticsGroupingKey`
+
+`getGameScoresheetStats` also exposes:
+
+- `analyticsGroupingScoresheetId`
+- `analyticsGroupingScoresheetSourceType`
+- `analyticsGroupingKey`
+- `linkageState`
+- `contributingVisibleScoresheets`
+- `contributingMatchCount`
+
+UI selectors should use `analyticsGroupingKey`, not local/shared ids directly.
+
+## Examples
+
+### original only
+
+- local scoresheet `Game A / Scoresheet 1`
+- three local matches fork from it
+- analytics family is `local:<scoresheetId>`
+- linkage state is `original`
+
+### shared unlinked
+
+- recipient sees shared scoresheet `Shared Cascadia`
+- recipient has not linked it
+- shared matches group under `shared:<shared_scoresheet.id>`
+- they remain separate from local Cascadia analytics
+
+### shared linked
+
+- recipient links `Shared Cascadia` to local scoresheet `My Cascadia`
+- shared matches now group under `local:<my_local_scoresheet_id>`
+- `linkageState` becomes `shared_linked`
+
+### same shared match grouped differently for different users
+
+- User A links the shared scoresheet to a local copy
+- User B leaves it unlinked
+- the same shared match contributes to `local:<id>` for User A
+- the same shared match contributes to `shared:<id>` for User B
+
+That difference is expected and is the reason analytics grouping is user-scoped.

--- a/packages/api/src/repositories/game/game-stats.repository.ts
+++ b/packages/api/src/repositories/game/game-stats.repository.ts
@@ -3,7 +3,6 @@ import { alias } from "drizzle-orm/pg-core";
 import { caseWhen } from "drizzle-plus";
 import { jsonBuildObject } from "drizzle-plus/pg";
 
-import type { TransactionType } from "@board-games/db/client";
 import { db } from "@board-games/db/client";
 import {
   image,
@@ -67,13 +66,18 @@ class GameStatsRepository {
         })
         .from(vMatchPlayerCanonicalForUser)
         .where(
-          and(
-            eq(vMatchPlayerCanonicalForUser.canonicalPlayerId, userPlayerId),
-            vMatchPlayerCanonicalViewerForUser(
-              vMatchPlayerCanonicalForUser,
-              userId,
-            ),
-          ),
+          userPlayerId === null
+            ? sql`false`
+            : and(
+                eq(
+                  vMatchPlayerCanonicalForUser.canonicalPlayerId,
+                  userPlayerId,
+                ),
+                vMatchPlayerCanonicalViewerForUser(
+                  vMatchPlayerCanonicalForUser,
+                  userId,
+                ),
+              ),
         )
         .orderBy(vMatchPlayerCanonicalForUser.canonicalMatchId),
     );

--- a/packages/api/src/repositories/game/game-stats.repository.ts
+++ b/packages/api/src/repositories/game/game-stats.repository.ts
@@ -223,7 +223,7 @@ class GameStatsRepository {
         analyticsGroupingScoresheetSourceType:
           vScoresheetAnalyticsForUser.analyticsGroupingScoresheetSourceType,
         analyticsGroupingKey: vScoresheetAnalyticsForUser.analyticsGroupingKey,
-        linkageState: vRoundAnalyticsForUser.linkageState,
+        linkageState: vScoresheetAnalyticsForUser.linkageState,
         visibleScoresheetId: vRoundAnalyticsForUser.visibleScoresheetId,
         visibleScoresheetSourceType:
           vScoresheetAnalyticsForUser.visibleScoresheetSourceType,

--- a/packages/api/src/repositories/game/game-stats.repository.ts
+++ b/packages/api/src/repositories/game/game-stats.repository.ts
@@ -1,9 +1,9 @@
-import { TRPCError } from "@trpc/server";
-import { and, eq, isNull, ne, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { caseWhen } from "drizzle-plus";
 import { jsonBuildObject } from "drizzle-plus/pg";
 
+import type { TransactionType } from "@board-games/db/client";
 import { db } from "@board-games/db/client";
 import {
   image,
@@ -13,33 +13,107 @@ import {
   round,
   roundPlayer,
   scoresheet,
-  sharedMatch,
   sharedRound,
+  sharedScoresheet,
 } from "@board-games/db/schema";
 import {
-  vMatchCanonical,
   vMatchPlayerCanonicalForUser,
+  vRoundAnalyticsForUser,
+  vScoresheetAnalyticsForUser,
 } from "@board-games/db/views";
 
 import {
-  vMatchCanonicalVisibleToUser,
   vMatchPlayerCanonicalViewerForUser,
   vMatchPlayerCanonicalViewerForUserExcludingNotSharedOnSharedBranch,
 } from "../../utils/drizzle/canonical-clauses";
 import type {
   GetGameArgs,
   GetGameScoresheetStatsDataArgs,
-  GetGameStatsHeaderArgs,
-  GetGameStatsHeaderOutputType,
+  GetGameStatsHeaderDataArgs,
 } from "./game.repository.types";
 
+const filterAnalyticsRowsToGame = (
+  userId: string,
+  input: GetGameArgs["input"],
+) =>
+  and(
+    eq(vScoresheetAnalyticsForUser.visibleToUserId, userId),
+    input.type === "original"
+      ? eq(vScoresheetAnalyticsForUser.canonicalGameId, input.id)
+      : eq(vScoresheetAnalyticsForUser.sharedGameId, input.sharedGameId),
+  );
+
 class GameStatsRepository {
+  public async getGameStatsHeaderData(args: GetGameStatsHeaderDataArgs) {
+    const { input, userId, userPlayerId } = args;
+
+    const scopedMatches = db.$with("scoped_matches").as(
+      db
+        .select({
+          matchId: vScoresheetAnalyticsForUser.matchId,
+          finished: vScoresheetAnalyticsForUser.finished,
+          duration: match.duration,
+        })
+        .from(vScoresheetAnalyticsForUser)
+        .innerJoin(match, eq(match.id, vScoresheetAnalyticsForUser.matchId))
+        .where(filterAnalyticsRowsToGame(userId, input)),
+    );
+
+    const userMatchPlayers = db.$with("user_match_players").as(
+      db
+        .selectDistinctOn([vMatchPlayerCanonicalForUser.canonicalMatchId], {
+          matchId: vMatchPlayerCanonicalForUser.canonicalMatchId,
+          winner: vMatchPlayerCanonicalForUser.winner,
+        })
+        .from(vMatchPlayerCanonicalForUser)
+        .where(
+          and(
+            eq(vMatchPlayerCanonicalForUser.canonicalPlayerId, userPlayerId),
+            vMatchPlayerCanonicalViewerForUser(
+              vMatchPlayerCanonicalForUser,
+              userId,
+            ),
+          ),
+        )
+        .orderBy(vMatchPlayerCanonicalForUser.canonicalMatchId),
+    );
+
+    const [stats] = await db
+      .with(scopedMatches, userMatchPlayers)
+      .select({
+        overallMatchesPlayed: sql<number>`COUNT(*) FILTER (WHERE ${scopedMatches.finished} = true)`,
+        userMatchesPlayed: sql<number>`COUNT(*) FILTER (WHERE ${scopedMatches.finished} = true AND ${userMatchPlayers.matchId} IS NOT NULL)`,
+        userWins: sql<number>`COUNT(*) FILTER (WHERE ${scopedMatches.finished} = true AND ${userMatchPlayers.winner} IS TRUE)`,
+        totalPlaytime: sql<number>`COALESCE(SUM(${scopedMatches.duration}) FILTER (WHERE ${scopedMatches.finished} = true AND ${scopedMatches.duration} >= 300), 0)`,
+        userTotalPlaytime: sql<number>`COALESCE(SUM(${scopedMatches.duration}) FILTER (WHERE ${scopedMatches.finished} = true AND ${scopedMatches.duration} >= 300 AND ${userMatchPlayers.matchId} IS NOT NULL), 0)`,
+        avgPlaytime: sql<number>`COALESCE(AVG(${scopedMatches.duration}) FILTER (WHERE ${scopedMatches.finished} = true AND ${scopedMatches.duration} >= 300), 0)`,
+        userAvgPlaytime: sql<number>`COALESCE(AVG(${scopedMatches.duration}) FILTER (WHERE ${scopedMatches.finished} = true AND ${scopedMatches.duration} >= 300 AND ${userMatchPlayers.matchId} IS NOT NULL), 0)`,
+      })
+      .from(scopedMatches)
+      .leftJoin(
+        userMatchPlayers,
+        eq(userMatchPlayers.matchId, scopedMatches.matchId),
+      );
+
+    return (
+      stats ?? {
+        overallMatchesPlayed: 0,
+        userMatchesPlayed: 0,
+        userWins: 0,
+        totalPlaytime: 0,
+        userTotalPlaytime: 0,
+        avgPlaytime: 0,
+        userAvgPlaytime: 0,
+      }
+    );
+  }
+
   public async getGamePlayerStatsData(args: GetGameArgs) {
     const { input, userId } = args;
 
-    const matchPlayers = await db
+    return db
       .select({
-        matchId: vMatchCanonical.matchId,
+        matchId: vScoresheetAnalyticsForUser.matchId,
         isCoop: scoresheet.isCoop,
         playerId: vMatchPlayerCanonicalForUser.canonicalPlayerId,
         type: vMatchPlayerCanonicalForUser.playerSourceType,
@@ -66,17 +140,17 @@ class GameStatsRepository {
         score: vMatchPlayerCanonicalForUser.score,
         placement: vMatchPlayerCanonicalForUser.placement,
       })
-      .from(vMatchCanonical)
+      .from(vScoresheetAnalyticsForUser)
       .innerJoin(
         scoresheet,
-        eq(scoresheet.id, vMatchCanonical.canonicalScoresheetId),
+        eq(scoresheet.id, vScoresheetAnalyticsForUser.matchScoresheetId),
       )
       .innerJoin(
         vMatchPlayerCanonicalForUser,
         and(
           eq(
             vMatchPlayerCanonicalForUser.canonicalMatchId,
-            vMatchCanonical.matchId,
+            vScoresheetAnalyticsForUser.matchId,
           ),
           vMatchPlayerCanonicalViewerForUserExcludingNotSharedOnSharedBranch(
             vMatchPlayerCanonicalForUser,
@@ -91,113 +165,10 @@ class GameStatsRepository {
       .leftJoin(image, eq(image.id, player.imageId))
       .where(
         and(
-          eq(vMatchCanonical.finished, true),
-          input.type === "original"
-            ? and(
-                eq(vMatchCanonical.canonicalGameId, input.id),
-                vMatchCanonicalVisibleToUser(vMatchCanonical, userId),
-              )
-            : and(
-                eq(vMatchCanonical.sharedGameId, input.sharedGameId),
-                vMatchCanonicalVisibleToUser(vMatchCanonical, userId),
-              ),
+          filterAnalyticsRowsToGame(userId, input),
+          eq(vScoresheetAnalyticsForUser.finished, true),
         ),
       );
-    return matchPlayers;
-  }
-
-  public async getGameStatsHeader(
-    args: GetGameStatsHeaderArgs,
-  ): Promise<GetGameStatsHeaderOutputType> {
-    const { input, userId } = args;
-
-    // Get user player
-    const userPlayer = await db.query.player.findFirst({
-      where: {
-        isUser: true,
-        createdBy: userId,
-      },
-    });
-    if (!userPlayer) {
-      throw new TRPCError({
-        code: "NOT_FOUND",
-        message: "Current user not found.",
-      });
-    }
-
-    // Create a CTE for user match players to check participation and wins
-    const userMatchPlayers = db.$with("user_match_players").as(
-      db
-        .selectDistinctOn([vMatchPlayerCanonicalForUser.canonicalMatchId], {
-          matchId: vMatchPlayerCanonicalForUser.canonicalMatchId,
-          winner: vMatchPlayerCanonicalForUser.winner,
-        })
-        .from(vMatchPlayerCanonicalForUser)
-        .where(
-          and(
-            eq(vMatchPlayerCanonicalForUser.canonicalPlayerId, userPlayer.id),
-            vMatchPlayerCanonicalViewerForUser(
-              vMatchPlayerCanonicalForUser,
-              userId,
-            ),
-          ),
-        )
-        .orderBy(vMatchPlayerCanonicalForUser.canonicalMatchId),
-    );
-
-    // Aggregate stats from matches
-    const [stats] = await db
-      .with(userMatchPlayers)
-      .select({
-        overallMatchesPlayed: sql<number>`COUNT(*) FILTER (WHERE ${match.finished} = true)`,
-        userMatchesPlayed: sql<number>`COUNT(*) FILTER (WHERE ${match.finished} = true AND ${userMatchPlayers.matchId} IS NOT NULL)`,
-        userWins: sql<number>`COUNT(*) FILTER (WHERE ${match.finished} = true AND ${userMatchPlayers.winner} IS TRUE)`,
-        totalPlaytime: sql<number>`COALESCE(SUM(${match.duration}) FILTER (WHERE ${match.finished} = true AND ${match.duration} >= 300), 0)`,
-        userTotalPlaytime: sql<number>`COALESCE(SUM(${match.duration}) FILTER (WHERE ${match.finished} = true AND ${match.duration} >= 300 AND ${userMatchPlayers.matchId} IS NOT NULL), 0)`,
-        avgPlaytime: sql<number>`COALESCE(AVG(${match.duration}) FILTER (WHERE ${match.finished} = true AND ${match.duration} >= 300), 0)`,
-        userAvgPlaytime: sql<number>`COALESCE(AVG(${match.duration}) FILTER (WHERE ${match.finished} = true AND ${match.duration} >= 300 AND ${userMatchPlayers.matchId} IS NOT NULL), 0)`,
-      })
-      .from(vMatchCanonical)
-      .innerJoin(match, eq(match.id, vMatchCanonical.matchId))
-      .leftJoin(
-        userMatchPlayers,
-        eq(userMatchPlayers.matchId, vMatchCanonical.matchId),
-      )
-      .where(
-        and(
-          input.type === "original"
-            ? eq(vMatchCanonical.canonicalGameId, input.id)
-            : eq(vMatchCanonical.sharedGameId, input.sharedGameId),
-          vMatchCanonicalVisibleToUser(vMatchCanonical, userId),
-        ),
-      );
-
-    if (!stats) {
-      return {
-        winRate: 0,
-        avgPlaytime: 0,
-        totalPlaytime: 0,
-        userTotalPlaytime: 0,
-        userAvgPlaytime: 0,
-        overallMatchesPlayed: 0,
-        userMatchesPlayed: 0,
-      };
-    }
-
-    const winRate =
-      stats.userMatchesPlayed > 0
-        ? (stats.userWins / stats.userMatchesPlayed) * 100
-        : 0;
-
-    return {
-      winRate: Number(Number(winRate).toFixed(2)),
-      avgPlaytime: Number(Number(stats.avgPlaytime).toFixed(0)),
-      totalPlaytime: Number(stats.totalPlaytime),
-      userTotalPlaytime: Number(stats.userTotalPlaytime),
-      userAvgPlaytime: Number(Number(stats.userAvgPlaytime).toFixed(0)),
-      overallMatchesPlayed: Number(stats.overallMatchesPlayed),
-      userMatchesPlayed: Number(stats.userMatchesPlayed),
-    };
   }
 
   public async getGameScoresheetStatsData(
@@ -206,62 +177,159 @@ class GameStatsRepository {
     const { input, userId, tx } = args;
     const database = tx ?? db;
 
-    // Match scoresheet and rounds; canonical resolution via parent_id or shared_round
-    const matchScoresheet = alias(scoresheet, "match_scoresheet");
-    const parentRound = alias(round, "parent_round");
-    const linkedRound = alias(round, "linked_round");
-    const canonicalScoresheet = alias(scoresheet, "canonical_scoresheet");
+    const analyticsScoresheetLocal = alias(
+      scoresheet,
+      "analytics_scoresheet_local",
+    );
+    const analyticsScoresheetShared = alias(
+      sharedScoresheet,
+      "analytics_scoresheet_shared",
+    );
+    const analyticsScoresheetSharedSource = alias(
+      scoresheet,
+      "analytics_scoresheet_shared_source",
+    );
+    const visibleScoresheetLocal = alias(
+      scoresheet,
+      "visible_scoresheet_local",
+    );
+    const visibleScoresheetShared = alias(
+      sharedScoresheet,
+      "visible_scoresheet_shared",
+    );
+    const visibleScoresheetSharedSource = alias(
+      scoresheet,
+      "visible_scoresheet_shared_source",
+    );
+    const analyticsRoundLocal = alias(round, "analytics_round_local");
+    const analyticsRoundShared = alias(sharedRound, "analytics_round_shared");
+    const analyticsRoundSharedSource = alias(
+      round,
+      "analytics_round_shared_source",
+    );
     const playerImage = alias(image, "player_image");
 
     const viewerKey = sql<string>`
-    COALESCE(
-      ${vMatchPlayerCanonicalForUser.sharedWithId},
-      ${vMatchPlayerCanonicalForUser.ownerId}
-    )
-  `;
-    const rows = await database
+      COALESCE(
+        ${vMatchPlayerCanonicalForUser.sharedWithId},
+        ${vMatchPlayerCanonicalForUser.ownerId}
+      )
+    `;
+
+    return database
       .select({
-        matchId: vMatchCanonical.matchId,
-        matchDate: vMatchCanonical.matchDate,
-
-        // Use the *match scoresheet* lineage as the top-level bucket
-        scoresheetParentId: sql<number>`
-      COALESCE(${canonicalScoresheet.parentId}, ${canonicalScoresheet.id})
-    `.as("scoresheet_parent_id"),
-
-        scoresheetParentName: canonicalScoresheet.name,
-        scoresheetRoundsScore: canonicalScoresheet.roundsScore,
-        scoresheetWinCondition: canonicalScoresheet.winCondition,
-
-        // Viewer-canonical round identity (linked > fork parent > self)
-        roundParentId: sql<number>`
-      COALESCE(${sharedRound.linkedRoundId}, ${round.parentId}, ${round.id})
-    `.as("round_parent_id"),
-        roundParentName: sql<string>`
-      COALESCE(${linkedRound.name}, ${parentRound.name}, ${round.name})
-    `.as("round_parent_name"),
-        roundParentType: sql<"Numeric" | "Checkbox">`
-      COALESCE(${linkedRound.type}, ${parentRound.type}, ${round.type})
-    `.as("round_parent_type"),
-        roundParentColor: sql<string | null>`
-      COALESCE(${linkedRound.color}, ${parentRound.color}, ${round.color})
-    `.as("round_parent_color"),
-        roundParentLookup: sql<number | null>`
-      COALESCE(${linkedRound.lookup}, ${parentRound.lookup}, ${round.lookup})
-    `.as("round_parent_lookup"),
-        roundParentModifier: sql<number | null>`
-      COALESCE(${linkedRound.modifier}, ${parentRound.modifier}, ${round.modifier})
-    `.as("round_parent_modifier"),
-        roundParentScore: sql<number>`
-      COALESCE(${linkedRound.score}, ${parentRound.score}, ${round.score})
-    `.as("round_parent_score"),
-
-        roundOrder: round.order,
-
-        // round-player stat
+        analyticsGroupingScoresheetId:
+          vRoundAnalyticsForUser.analyticsGroupingScoresheetId,
+        analyticsGroupingScoresheetSourceType:
+          vScoresheetAnalyticsForUser.analyticsGroupingScoresheetSourceType,
+        analyticsGroupingKey: vScoresheetAnalyticsForUser.analyticsGroupingKey,
+        linkageState: vRoundAnalyticsForUser.linkageState,
+        visibleScoresheetId: vRoundAnalyticsForUser.visibleScoresheetId,
+        visibleScoresheetSourceType:
+          vScoresheetAnalyticsForUser.visibleScoresheetSourceType,
+        visibleScoresheetName: sql<string>`
+          COALESCE(
+            ${visibleScoresheetLocal.name},
+            ${visibleScoresheetSharedSource.name}
+          )
+        `.as("visible_scoresheet_name"),
+        analyticsScoresheetName: sql<string>`
+          COALESCE(
+            ${analyticsScoresheetLocal.name},
+            ${analyticsScoresheetSharedSource.name}
+          )
+        `.as("analytics_scoresheet_name"),
+        analyticsScoresheetIsCoop: sql<boolean>`
+          COALESCE(
+            ${analyticsScoresheetLocal.isCoop},
+            ${analyticsScoresheetSharedSource.isCoop}
+          )
+        `.as("analytics_scoresheet_is_coop"),
+        analyticsScoresheetTargetScore: sql<number>`
+          COALESCE(
+            ${analyticsScoresheetLocal.targetScore},
+            ${analyticsScoresheetSharedSource.targetScore}
+          )
+        `.as("analytics_scoresheet_target_score"),
+        analyticsScoresheetRoundsScore: sql<
+          "Aggregate" | "Manual" | "Best Of" | "None"
+        >`
+          COALESCE(
+            ${analyticsScoresheetLocal.roundsScore},
+            ${analyticsScoresheetSharedSource.roundsScore}
+          )
+        `.as("analytics_scoresheet_rounds_score"),
+        analyticsScoresheetWinCondition: sql<
+          | "Manual"
+          | "Highest Score"
+          | "Lowest Score"
+          | "No Winner"
+          | "Target Score"
+        >`
+          COALESCE(
+            ${analyticsScoresheetLocal.winCondition},
+            ${analyticsScoresheetSharedSource.winCondition}
+          )
+        `.as("analytics_scoresheet_win_condition"),
+        analyticsScoresheetIsDefault: sql<boolean>`
+          CASE
+            WHEN ${vScoresheetAnalyticsForUser.analyticsGroupingScoresheetSourceType} = 'local'
+              THEN COALESCE(${analyticsScoresheetLocal.type} = 'Default', false)
+            ELSE COALESCE(${analyticsScoresheetShared.isDefault}, false)
+          END
+        `.as("analytics_scoresheet_is_default"),
+        analyticsScoresheetPermission: analyticsScoresheetShared.permission,
+        matchId: vRoundAnalyticsForUser.matchId,
+        matchDate: match.date,
+        analyticsGroupingRoundId:
+          vRoundAnalyticsForUser.analyticsGroupingRoundId,
+        analyticsGroupingRoundSourceType:
+          vRoundAnalyticsForUser.analyticsGroupingRoundSourceType,
+        analyticsGroupingRoundKey:
+          vRoundAnalyticsForUser.analyticsGroupingRoundKey,
+        analyticsRoundName: sql<string>`
+          COALESCE(
+            ${analyticsRoundLocal.name},
+            ${analyticsRoundSharedSource.name}
+          )
+        `.as("analytics_round_name"),
+        analyticsRoundType: sql<"Numeric" | "Checkbox">`
+          COALESCE(
+            ${analyticsRoundLocal.type},
+            ${analyticsRoundSharedSource.type}
+          )
+        `.as("analytics_round_type"),
+        analyticsRoundColor: sql<string | null>`
+          COALESCE(
+            ${analyticsRoundLocal.color},
+            ${analyticsRoundSharedSource.color}
+          )
+        `.as("analytics_round_color"),
+        analyticsRoundLookup: sql<number | null>`
+          COALESCE(
+            ${analyticsRoundLocal.lookup},
+            ${analyticsRoundSharedSource.lookup}
+          )
+        `.as("analytics_round_lookup"),
+        analyticsRoundModifier: sql<number | null>`
+          COALESCE(
+            ${analyticsRoundLocal.modifier},
+            ${analyticsRoundSharedSource.modifier}
+          )
+        `.as("analytics_round_modifier"),
+        analyticsRoundScore: sql<number>`
+          COALESCE(
+            ${analyticsRoundLocal.score},
+            ${analyticsRoundSharedSource.score}
+          )
+        `.as("analytics_round_score"),
+        analyticsRoundOrder: sql<number>`
+          COALESCE(
+            ${analyticsRoundLocal.order},
+            ${analyticsRoundSharedSource.order}
+          )
+        `.as("analytics_round_order"),
         roundPlayerScore: roundPlayer.score,
-
-        // match-player + player identity
         matchPlayerId: matchPlayer.id,
         playerId: player.id,
         playerName: player.name,
@@ -269,31 +337,37 @@ class GameStatsRepository {
         playerSharedId: vMatchPlayerCanonicalForUser.sharedPlayerId,
         playerLinkedId: vMatchPlayerCanonicalForUser.linkedPlayerId,
         playerIsUser: player.isUser,
-
         playerImageName: playerImage.name,
         playerImageUrl: playerImage.url,
         playerImageType: playerImage.type,
-
         matchPlayerWinner: matchPlayer.winner,
         matchPlayerScore: matchPlayer.score,
         matchPlayerPlacement: matchPlayer.placement,
       })
-      .from(vMatchCanonical)
-      .innerJoin(match, eq(match.id, vMatchCanonical.matchId))
-      .innerJoin(matchScoresheet, eq(matchScoresheet.id, match.scoresheetId))
+      .from(vRoundAnalyticsForUser)
       .innerJoin(
-        round,
+        vScoresheetAnalyticsForUser,
         and(
-          eq(round.scoresheetId, matchScoresheet.id),
-          isNull(round.deletedAt),
+          eq(
+            vScoresheetAnalyticsForUser.matchId,
+            vRoundAnalyticsForUser.matchId,
+          ),
+          eq(
+            vScoresheetAnalyticsForUser.visibleToUserId,
+            vRoundAnalyticsForUser.visibleToUserId,
+          ),
         ),
       )
-      .innerJoin(roundPlayer, eq(roundPlayer.roundId, round.id))
+      .innerJoin(match, eq(match.id, vRoundAnalyticsForUser.matchId))
+      .innerJoin(
+        roundPlayer,
+        eq(roundPlayer.roundId, vRoundAnalyticsForUser.matchRoundId),
+      )
       .innerJoin(
         matchPlayer,
         and(
           eq(matchPlayer.id, roundPlayer.matchPlayerId),
-          eq(matchPlayer.matchId, match.id),
+          eq(matchPlayer.matchId, vRoundAnalyticsForUser.matchId),
         ),
       )
       .innerJoin(
@@ -301,47 +375,119 @@ class GameStatsRepository {
         and(
           eq(
             vMatchPlayerCanonicalForUser.canonicalMatchId,
-            vMatchCanonical.matchId,
+            vRoundAnalyticsForUser.matchId,
           ),
           eq(vMatchPlayerCanonicalForUser.baseMatchPlayerId, matchPlayer.id),
-          eq(viewerKey, vMatchCanonical.visibleToUserId),
+          eq(viewerKey, vRoundAnalyticsForUser.visibleToUserId),
         ),
       )
       .innerJoin(
         player,
         and(
           eq(player.id, vMatchPlayerCanonicalForUser.canonicalPlayerId),
-          isNull(player.deletedAt),
-        ),
-      )
-      .leftJoin(playerImage, eq(playerImage.id, player.imageId))
-      .leftJoin(sharedMatch, eq(sharedMatch.id, vMatchCanonical.sharedMatchId))
-      .leftJoin(
-        sharedRound,
-        and(
-          eq(sharedRound.roundId, round.id),
-          eq(sharedRound.sharedScoresheetId, sharedMatch.sharedScoresheetId),
-        ),
-      )
-      .leftJoin(linkedRound, eq(linkedRound.id, sharedRound.linkedRoundId))
-      .leftJoin(parentRound, eq(parentRound.id, round.parentId))
-      .innerJoin(
-        canonicalScoresheet,
-        eq(canonicalScoresheet.id, vMatchCanonical.canonicalScoresheetId),
-      )
-      .where(
-        and(
-          eq(vMatchCanonical.finished, true),
-          vMatchCanonicalVisibleToUser(vMatchCanonical, userId),
-          input.type === "original"
-            ? eq(vMatchCanonical.canonicalGameId, input.id)
-            : eq(vMatchCanonical.sharedGameId, input.sharedGameId),
           ne(vMatchPlayerCanonicalForUser.playerSourceType, "not-shared"),
         ),
       )
-      .orderBy(vMatchCanonical.matchDate, round.order, matchPlayer.id);
-
-    return rows;
+      .leftJoin(playerImage, eq(playerImage.id, player.imageId))
+      .leftJoin(
+        analyticsScoresheetLocal,
+        and(
+          eq(
+            vScoresheetAnalyticsForUser.analyticsGroupingScoresheetSourceType,
+            "local",
+          ),
+          eq(
+            analyticsScoresheetLocal.id,
+            vRoundAnalyticsForUser.analyticsGroupingScoresheetId,
+          ),
+        ),
+      )
+      .leftJoin(
+        analyticsScoresheetShared,
+        and(
+          eq(
+            vScoresheetAnalyticsForUser.analyticsGroupingScoresheetSourceType,
+            "shared",
+          ),
+          eq(
+            analyticsScoresheetShared.id,
+            vRoundAnalyticsForUser.analyticsGroupingScoresheetId,
+          ),
+        ),
+      )
+      .leftJoin(
+        analyticsScoresheetSharedSource,
+        eq(
+          analyticsScoresheetSharedSource.id,
+          analyticsScoresheetShared.scoresheetId,
+        ),
+      )
+      .leftJoin(
+        visibleScoresheetLocal,
+        and(
+          eq(vScoresheetAnalyticsForUser.visibleScoresheetSourceType, "local"),
+          eq(
+            visibleScoresheetLocal.id,
+            vRoundAnalyticsForUser.visibleScoresheetId,
+          ),
+        ),
+      )
+      .leftJoin(
+        visibleScoresheetShared,
+        and(
+          eq(vScoresheetAnalyticsForUser.visibleScoresheetSourceType, "shared"),
+          eq(
+            visibleScoresheetShared.id,
+            vRoundAnalyticsForUser.visibleScoresheetId,
+          ),
+        ),
+      )
+      .leftJoin(
+        visibleScoresheetSharedSource,
+        eq(
+          visibleScoresheetSharedSource.id,
+          visibleScoresheetShared.scoresheetId,
+        ),
+      )
+      .leftJoin(
+        analyticsRoundLocal,
+        and(
+          eq(vRoundAnalyticsForUser.analyticsGroupingRoundSourceType, "local"),
+          eq(
+            analyticsRoundLocal.id,
+            vRoundAnalyticsForUser.analyticsGroupingRoundId,
+          ),
+        ),
+      )
+      .leftJoin(
+        analyticsRoundShared,
+        and(
+          eq(vRoundAnalyticsForUser.analyticsGroupingRoundSourceType, "shared"),
+          eq(
+            analyticsRoundShared.id,
+            vRoundAnalyticsForUser.analyticsGroupingRoundId,
+          ),
+        ),
+      )
+      .leftJoin(
+        analyticsRoundSharedSource,
+        eq(analyticsRoundSharedSource.id, analyticsRoundShared.roundId),
+      )
+      .where(
+        and(
+          eq(vRoundAnalyticsForUser.visibleToUserId, userId),
+          eq(vScoresheetAnalyticsForUser.finished, true),
+          input.type === "original"
+            ? eq(vRoundAnalyticsForUser.canonicalGameId, input.id)
+            : eq(vScoresheetAnalyticsForUser.sharedGameId, input.sharedGameId),
+        ),
+      )
+      .orderBy(
+        vScoresheetAnalyticsForUser.analyticsGroupingKey,
+        sql`COALESCE(${analyticsRoundLocal.order}, ${analyticsRoundSharedSource.order})`,
+        match.date,
+        matchPlayer.id,
+      );
   }
 }
 

--- a/packages/api/src/repositories/game/game.repository.types.ts
+++ b/packages/api/src/repositories/game/game.repository.types.ts
@@ -130,7 +130,6 @@ export type GetGameStatsHeaderDataArgs = {
   userId: string;
   userPlayerId: number;
   input: GetGameInputType;
-  tx?: TransactionType;
 };
 
 export interface GetGameStatsHeaderOutputType {

--- a/packages/api/src/repositories/game/game.repository.types.ts
+++ b/packages/api/src/repositories/game/game.repository.types.ts
@@ -8,6 +8,7 @@ import type {
 } from "../../routers/game/game.input";
 import type { GetLocationInputType } from "../../routers/location/location.input";
 import type {
+  TransactionType,
   WithRepoUserIdInput,
   WithRepoUserIdInputRequiredTx,
   WithTxInput,
@@ -124,6 +125,13 @@ export type DeleteSharedGameRoleArgs = WithTxInput<{
 }>;
 
 export type GetGameStatsHeaderArgs = WithRepoUserIdInput<GetGameInputType>;
+
+export type GetGameStatsHeaderDataArgs = {
+  userId: string;
+  userPlayerId: number;
+  input: GetGameInputType;
+  tx?: TransactionType;
+};
 
 export interface GetGameStatsHeaderOutputType {
   winRate: number; // 0-100 percentage

--- a/packages/api/src/repositories/game/game.repository.types.ts
+++ b/packages/api/src/repositories/game/game.repository.types.ts
@@ -8,7 +8,6 @@ import type {
 } from "../../routers/game/game.input";
 import type { GetLocationInputType } from "../../routers/location/location.input";
 import type {
-  TransactionType,
   WithRepoUserIdInput,
   WithRepoUserIdInputRequiredTx,
   WithTxInput,
@@ -128,7 +127,7 @@ export type GetGameStatsHeaderArgs = WithRepoUserIdInput<GetGameInputType>;
 
 export type GetGameStatsHeaderDataArgs = {
   userId: string;
-  userPlayerId: number;
+  userPlayerId: number | null;
   input: GetGameInputType;
 };
 

--- a/packages/api/src/repositories/scoresheet/round.repository.ts
+++ b/packages/api/src/repositories/scoresheet/round.repository.ts
@@ -1,9 +1,10 @@
 import type { AnyColumn, SQL } from "drizzle-orm";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 
 import type { TransactionType } from "@board-games/db/client";
 import { db } from "@board-games/db/client";
 import { round, sharedRound } from "@board-games/db/schema";
+import { vRoundAnalyticsForUser } from "@board-games/db/views";
 
 import type {
   InsertRoundInputType,
@@ -260,6 +261,144 @@ class RoundRepository {
       )
       .returning();
     return linkedSharedRound;
+  }
+
+  public async linkSharedRoundAnalytics(args: {
+    input: {
+      sharedRoundId: number;
+      linkedRoundId: number | null;
+      sharedScoresheetId: number;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    const [updatedSharedRound] = await database
+      .update(sharedRound)
+      .set({ analyticsLinkedRoundId: input.linkedRoundId })
+      .where(
+        and(
+          eq(sharedRound.id, input.sharedRoundId),
+          eq(sharedRound.sharedScoresheetId, input.sharedScoresheetId),
+        ),
+      )
+      .returning();
+    return updatedSharedRound;
+  }
+
+  public async bulkLinkSharedRoundsAnalytics(args: {
+    input: {
+      links: {
+        sharedRoundId: number;
+        linkedRoundId: number | null;
+      }[];
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    if (input.links.length === 0) {
+      return [];
+    }
+    const updatedSharedRounds = await Promise.all(
+      input.links.map((link) =>
+        database
+          .update(sharedRound)
+          .set({
+            analyticsLinkedRoundId: link.linkedRoundId,
+          })
+          .where(eq(sharedRound.id, link.sharedRoundId))
+          .returning()
+          .then((rows) => rows[0] ?? null),
+      ),
+    );
+    return updatedSharedRounds.filter((row) => row !== null);
+  }
+
+  public async getSharedRoundsForAnalytics(args: {
+    input: {
+      sharedScoresheetId: number;
+      sharedWithId: string;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    return database.query.sharedRound.findMany({
+      where: {
+        sharedScoresheetId: input.sharedScoresheetId,
+        sharedWithId: input.sharedWithId,
+      },
+      with: {
+        round: true,
+        analyticsLinkedRound: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+  }
+
+  public async setLegacyLinkedRoundIdIfNeeded(args: {
+    input: {
+      links: {
+        sharedRoundId: number;
+        linkedRoundId: number;
+      }[];
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    if (input.links.length === 0) {
+      return [];
+    }
+    const updatedSharedRounds = await Promise.all(
+      input.links.map((link) =>
+        database
+          .update(sharedRound)
+          .set({
+            linkedRoundId: link.linkedRoundId,
+          })
+          .where(
+            and(
+              eq(sharedRound.id, link.sharedRoundId),
+              isNull(sharedRound.linkedRoundId),
+            ),
+          )
+          .returning()
+          .then((rows) => rows[0] ?? null),
+      ),
+    );
+    return updatedSharedRounds.filter((row) => row !== null);
+  }
+
+  public async getRoundAnalyticsFamilyRows(args: {
+    input: {
+      userId: string;
+      analyticsGroupingRoundId: number;
+      analyticsGroupingRoundSourceType: "local" | "shared";
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    return database
+      .select()
+      .from(vRoundAnalyticsForUser)
+      .where(
+        and(
+          eq(vRoundAnalyticsForUser.visibleToUserId, input.userId),
+          eq(
+            vRoundAnalyticsForUser.analyticsGroupingRoundId,
+            input.analyticsGroupingRoundId,
+          ),
+          eq(
+            vRoundAnalyticsForUser.analyticsGroupingRoundSourceType,
+            input.analyticsGroupingRoundSourceType,
+          ),
+        ),
+      );
   }
 }
 

--- a/packages/api/src/repositories/scoresheet/round.repository.ts
+++ b/packages/api/src/repositories/scoresheet/round.repository.ts
@@ -26,6 +26,7 @@ interface CaseEntry {
  * Returns `undefined` when no entries are provided (field was never set).
  */
 const buildCaseExpression = (
+  idColumn: AnyColumn | SQL,
   column: AnyColumn | SQL,
   entries: CaseEntry[],
 ): SQL | undefined => {
@@ -33,7 +34,7 @@ const buildCaseExpression = (
   const chunks: SQL[] = [sql`(case`];
   for (const e of entries) {
     chunks.push(
-      sql`when ${round.id} = ${e.id} then ${sql`${e.value}::${sql.raw(e.cast)}`}`,
+      sql`when ${idColumn} = ${e.id} then ${sql`${e.value}::${sql.raw(e.cast)}`}`,
     );
   }
   chunks.push(sql`else ${column} end)`);
@@ -171,7 +172,7 @@ class RoundRepository {
           entries.push({ id: inputRound.id, value, cast: field.cast });
         }
       }
-      const expr = buildCaseExpression(field.column, entries);
+      const expr = buildCaseExpression(round.id, field.column, entries);
       if (expr) {
         setData[field.key] = expr;
       }
@@ -393,24 +394,42 @@ class RoundRepository {
       }
     }
 
-    const updatedSharedRounds = await Promise.all(
-      input.links.map((link) =>
-        database
-          .update(sharedRound)
-          .set({
-            analyticsLinkedRoundId: link.linkedRoundId,
-          })
-          .where(
-            and(
-              eq(sharedRound.id, link.sharedRoundId),
-              eq(sharedRound.sharedScoresheetId, input.sharedScoresheetId),
-            ),
-          )
-          .returning()
-          .then((rows) => rows[0] ?? null),
-      ),
+    const analyticsLinkedRoundExpression = buildCaseExpression(
+      sharedRound.id,
+      sharedRound.analyticsLinkedRoundId,
+      input.links.map((link) => ({
+        id: link.sharedRoundId,
+        value: link.linkedRoundId,
+        cast: "integer",
+      })),
     );
-    return updatedSharedRounds.filter((row) => row !== null);
+    if (!analyticsLinkedRoundExpression) {
+      return [];
+    }
+
+    const updatedSharedRounds = await database
+      .update(sharedRound)
+      .set({
+        analyticsLinkedRoundId: analyticsLinkedRoundExpression,
+      })
+      .where(
+        and(
+          eq(sharedRound.sharedScoresheetId, input.sharedScoresheetId),
+          inArray(sharedRound.id, sharedRoundIds),
+        ),
+      )
+      .returning();
+
+    const updatedSharedRoundById = new Map(
+      updatedSharedRounds.map((sharedRoundRow) => [
+        sharedRoundRow.id,
+        sharedRoundRow,
+      ]),
+    );
+
+    return input.links
+      .map((link) => updatedSharedRoundById.get(link.sharedRoundId) ?? null)
+      .filter((row) => row !== null);
   }
 
   public async clearSharedRoundsAnalyticsLinksForScoresheet(args: {
@@ -481,24 +500,54 @@ class RoundRepository {
     if (input.links.length === 0) {
       return [];
     }
-    const updatedSharedRounds = await Promise.all(
-      input.links.map((link) =>
-        database
-          .update(sharedRound)
-          .set({
-            linkedRoundId: link.linkedRoundId,
-          })
-          .where(
-            and(
-              eq(sharedRound.id, link.sharedRoundId),
-              isNull(sharedRound.linkedRoundId),
-            ),
-          )
-          .returning()
-          .then((rows) => rows[0] ?? null),
-      ),
+
+    const uniqueSharedRoundIds = new Set<number>();
+    for (const link of input.links) {
+      if (uniqueSharedRoundIds.has(link.sharedRoundId)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "duplicate sharedRoundId in links",
+        });
+      }
+      uniqueSharedRoundIds.add(link.sharedRoundId);
+    }
+
+    const linkedRoundExpression = buildCaseExpression(
+      sharedRound.id,
+      sharedRound.linkedRoundId,
+      input.links.map((link) => ({
+        id: link.sharedRoundId,
+        value: link.linkedRoundId,
+        cast: "integer",
+      })),
     );
-    return updatedSharedRounds.filter((row) => row !== null);
+    if (!linkedRoundExpression) {
+      return [];
+    }
+
+    const updatedSharedRounds = await database
+      .update(sharedRound)
+      .set({
+        linkedRoundId: linkedRoundExpression,
+      })
+      .where(
+        and(
+          inArray(sharedRound.id, Array.from(uniqueSharedRoundIds)),
+          isNull(sharedRound.linkedRoundId),
+        ),
+      )
+      .returning();
+
+    const updatedSharedRoundById = new Map(
+      updatedSharedRounds.map((sharedRoundRow) => [
+        sharedRoundRow.id,
+        sharedRoundRow,
+      ]),
+    );
+
+    return input.links
+      .map((link) => updatedSharedRoundById.get(link.sharedRoundId) ?? null)
+      .filter((row) => row !== null);
   }
 
   public async getRoundAnalyticsFamilyRows(args: {

--- a/packages/api/src/repositories/scoresheet/round.repository.ts
+++ b/packages/api/src/repositories/scoresheet/round.repository.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import type { AnyColumn, SQL } from "drizzle-orm";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 
@@ -288,6 +289,8 @@ class RoundRepository {
 
   public async bulkLinkSharedRoundsAnalytics(args: {
     input: {
+      sharedScoresheetId: number;
+      linkedScoresheetId: number | null;
       links: {
         sharedRoundId: number;
         linkedRoundId: number | null;
@@ -300,6 +303,96 @@ class RoundRepository {
     if (input.links.length === 0) {
       return [];
     }
+
+    const uniqueSharedRoundIds = new Set<number>();
+    for (const link of input.links) {
+      if (uniqueSharedRoundIds.has(link.sharedRoundId)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "duplicate sharedRoundId in links",
+        });
+      }
+      uniqueSharedRoundIds.add(link.sharedRoundId);
+    }
+
+    const sharedRoundIds = Array.from(uniqueSharedRoundIds);
+    const sharedRounds = await database.query.sharedRound.findMany({
+      columns: {
+        id: true,
+        sharedScoresheetId: true,
+      },
+      where: {
+        id: {
+          in: sharedRoundIds,
+        },
+      },
+    });
+
+    if (sharedRounds.length !== sharedRoundIds.length) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "One or more shared rounds were not found.",
+      });
+    }
+
+    for (const existingSharedRound of sharedRounds) {
+      if (existingSharedRound.sharedScoresheetId !== input.sharedScoresheetId) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Shared round does not belong to this shared scoresheet.",
+        });
+      }
+    }
+
+    const linkedRoundIds = Array.from(
+      new Set(
+        input.links
+          .map((link) => link.linkedRoundId)
+          .filter(
+            (linkedRoundId): linkedRoundId is number => linkedRoundId !== null,
+          ),
+      ),
+    );
+
+    if (linkedRoundIds.length > 0 && input.linkedScoresheetId === null) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message:
+          "Analytics-linked rounds require an analytics-linked local scoresheet.",
+      });
+    }
+
+    if (linkedRoundIds.length > 0) {
+      const linkedRounds = await database.query.round.findMany({
+        columns: {
+          id: true,
+          scoresheetId: true,
+        },
+        where: {
+          id: {
+            in: linkedRoundIds,
+          },
+        },
+      });
+
+      if (linkedRounds.length !== linkedRoundIds.length) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "One or more analytics-linked rounds were not found.",
+        });
+      }
+
+      for (const linkedRound of linkedRounds) {
+        if (linkedRound.scoresheetId !== input.linkedScoresheetId) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Analytics-linked round must belong to the analytics-linked local scoresheet.",
+          });
+        }
+      }
+    }
+
     const updatedSharedRounds = await Promise.all(
       input.links.map((link) =>
         database
@@ -307,12 +400,47 @@ class RoundRepository {
           .set({
             analyticsLinkedRoundId: link.linkedRoundId,
           })
-          .where(eq(sharedRound.id, link.sharedRoundId))
+          .where(
+            and(
+              eq(sharedRound.id, link.sharedRoundId),
+              eq(sharedRound.sharedScoresheetId, input.sharedScoresheetId),
+            ),
+          )
           .returning()
           .then((rows) => rows[0] ?? null),
       ),
     );
     return updatedSharedRounds.filter((row) => row !== null);
+  }
+
+  public async clearSharedRoundsAnalyticsLinksForScoresheet(args: {
+    input: {
+      sharedScoresheetId: number;
+      linkedScoresheetId: number;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+
+    return database
+      .update(sharedRound)
+      .set({
+        analyticsLinkedRoundId: null,
+      })
+      .where(
+        and(
+          eq(sharedRound.sharedScoresheetId, input.sharedScoresheetId),
+          inArray(
+            sharedRound.analyticsLinkedRoundId,
+            database
+              .select({ id: round.id })
+              .from(round)
+              .where(eq(round.scoresheetId, input.linkedScoresheetId)),
+          ),
+        ),
+      )
+      .returning();
   }
 
   public async getSharedRoundsForAnalytics(args: {

--- a/packages/api/src/repositories/scoresheet/scoresheet.repository.ts
+++ b/packages/api/src/repositories/scoresheet/scoresheet.repository.ts
@@ -295,6 +295,7 @@ class ScoresheetRepository {
     input: {
       sharedScoresheetId: number;
       linkedScoresheetId: number | null;
+      sharedWithId: string;
     };
     tx?: TransactionType;
   }) {
@@ -305,7 +306,12 @@ class ScoresheetRepository {
       .set({
         analyticsLinkedScoresheetId: input.linkedScoresheetId,
       })
-      .where(eq(sharedScoresheet.id, input.sharedScoresheetId))
+      .where(
+        and(
+          eq(sharedScoresheet.id, input.sharedScoresheetId),
+          eq(sharedScoresheet.sharedWithId, input.sharedWithId),
+        ),
+      )
       .returning();
     return updatedSharedScoresheet;
   }

--- a/packages/api/src/repositories/scoresheet/scoresheet.repository.ts
+++ b/packages/api/src/repositories/scoresheet/scoresheet.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, or } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 
 import type {
   Filter,
@@ -29,6 +29,55 @@ class ScoresheetRepository {
       .values(input)
       .returning();
     return returningScoresheet;
+  }
+  public async insertMaterializedLocalScoresheetIfAbsent(
+    input: InsertScoreSheetInputType & {
+      createdBy: string;
+      forkedFromSharedScoresheetId: number;
+    },
+    tx?: TransactionType,
+  ) {
+    const database = tx ?? db;
+    const [insertedScoresheet] = await database
+      .insert(scoresheet)
+      .values(input)
+      .onConflictDoNothing({
+        target: [scoresheet.createdBy, scoresheet.forkedFromSharedScoresheetId],
+        where: sql`${scoresheet.deletedAt} IS NULL AND ${scoresheet.forkedFromSharedScoresheetId} IS NOT NULL`,
+      })
+      .returning();
+
+    if (insertedScoresheet) {
+      return {
+        scoresheet: insertedScoresheet,
+        wasInserted: true,
+      };
+    }
+
+    const existingScoresheet = await database.query.scoresheet.findFirst({
+      where: {
+        createdBy: input.createdBy,
+        forkedFromSharedScoresheetId: input.forkedFromSharedScoresheetId,
+        deletedAt: {
+          isNull: true,
+        },
+        type: {
+          in: ["Game", "Default"],
+        },
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+
+    if (!existingScoresheet) {
+      return undefined;
+    }
+
+    return {
+      scoresheet: existingScoresheet,
+      wasInserted: false,
+    };
   }
   public async insertShared(
     input: InsertSharedScoreSheetInputType,
@@ -371,6 +420,7 @@ class ScoresheetRepository {
   public async getSharedForMaterialization(args: {
     input: {
       sharedScoresheetId: number;
+      sharedGameId: number;
       userId: string;
     };
     tx?: TransactionType;
@@ -381,6 +431,7 @@ class ScoresheetRepository {
       where: {
         id: input.sharedScoresheetId,
         sharedWithId: input.userId,
+        sharedGameId: input.sharedGameId,
         type: "game",
       },
       with: {
@@ -415,7 +466,7 @@ class ScoresheetRepository {
             isNull: true,
           },
           type: {
-            OR: [{ eq: "Game" }, { eq: "Default" }],
+            in: ["Game", "Default"],
           },
         },
         with: {

--- a/packages/api/src/repositories/scoresheet/scoresheet.repository.ts
+++ b/packages/api/src/repositories/scoresheet/scoresheet.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, isNull, or } from "drizzle-orm";
 
 import type {
   Filter,
@@ -14,6 +14,7 @@ import type {
 } from "@board-games/db/constants";
 import { db } from "@board-games/db/client";
 import { scoresheet, sharedScoresheet } from "@board-games/db/schema";
+import { vScoresheetAnalyticsForUser } from "@board-games/db/views";
 
 import type {
   InsertScoreSheetInputType,
@@ -289,6 +290,237 @@ class ScoresheetRepository {
       .returning();
     return linkedScoresheet;
   }
+
+  public async linkSharedScoresheetAnalytics(args: {
+    input: {
+      sharedScoresheetId: number;
+      linkedScoresheetId: number | null;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    const [updatedSharedScoresheet] = await database
+      .update(sharedScoresheet)
+      .set({
+        analyticsLinkedScoresheetId: input.linkedScoresheetId,
+      })
+      .where(eq(sharedScoresheet.id, input.sharedScoresheetId))
+      .returning();
+    return updatedSharedScoresheet;
+  }
+
+  public async getSharedScoresheetAnalyticsState(args: {
+    input: {
+      sharedScoresheetId: number;
+      userId: string;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    return database.query.sharedScoresheet.findFirst({
+      where: {
+        id: input.sharedScoresheetId,
+        sharedWithId: input.userId,
+      },
+      with: {
+        scoresheet: true,
+        sharedGame: true,
+        analyticsLinkedScoresheet: true,
+        sharedRounds: {
+          with: {
+            round: true,
+            analyticsLinkedRound: true,
+          },
+          orderBy: {
+            id: "asc",
+          },
+        },
+      },
+    });
+  }
+
+  public async getSharedScoresheetByIdForAnalytics(args: {
+    input: {
+      sharedScoresheetId: number;
+      sharedWithId: string;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    return database.query.sharedScoresheet.findFirst({
+      where: {
+        id: input.sharedScoresheetId,
+        sharedWithId: input.sharedWithId,
+      },
+      with: {
+        scoresheet: true,
+        analyticsLinkedScoresheet: true,
+      },
+    });
+  }
+
+  public async getSharedForMaterialization(args: {
+    input: {
+      sharedScoresheetId: number;
+      userId: string;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    return database.query.sharedScoresheet.findFirst({
+      where: {
+        id: input.sharedScoresheetId,
+        sharedWithId: input.userId,
+        type: "game",
+      },
+      with: {
+        scoresheet: true,
+        sharedRounds: {
+          with: {
+            round: true,
+          },
+          orderBy: {
+            id: "asc",
+          },
+        },
+      },
+    });
+  }
+
+  public async getMaterializedLocalScoresheetForSharedScoresheet(args: {
+    input: {
+      sharedScoresheetId: number;
+      userId: string;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    const materializedFromProvenance =
+      await database.query.scoresheet.findFirst({
+        where: {
+          createdBy: input.userId,
+          forkedFromSharedScoresheetId: input.sharedScoresheetId,
+          deletedAt: {
+            isNull: true,
+          },
+          type: {
+            OR: [{ eq: "Game" }, { eq: "Default" }],
+          },
+        },
+        with: {
+          rounds: {
+            where: {
+              deletedAt: {
+                isNull: true,
+              },
+            },
+            orderBy: {
+              order: "asc",
+            },
+          },
+        },
+        orderBy: {
+          id: "asc",
+        },
+      });
+    if (materializedFromProvenance) {
+      return materializedFromProvenance;
+    }
+
+    const sharedScoresheetRow = await database.query.sharedScoresheet.findFirst(
+      {
+        where: {
+          id: input.sharedScoresheetId,
+          sharedWithId: input.userId,
+        },
+        columns: {
+          linkedScoresheetId: true,
+        },
+      },
+    );
+    if (!sharedScoresheetRow?.linkedScoresheetId) {
+      return undefined;
+    }
+
+    return database.query.scoresheet.findFirst({
+      where: {
+        id: sharedScoresheetRow.linkedScoresheetId,
+        createdBy: input.userId,
+        deletedAt: {
+          isNull: true,
+        },
+      },
+      with: {
+        rounds: {
+          where: {
+            deletedAt: {
+              isNull: true,
+            },
+          },
+          orderBy: {
+            order: "asc",
+          },
+        },
+      },
+    });
+  }
+
+  public async setLegacyLinkedScoresheetIdIfNeeded(args: {
+    input: {
+      sharedScoresheetId: number;
+      linkedScoresheetId: number;
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    const [updatedSharedScoresheet] = await database
+      .update(sharedScoresheet)
+      .set({
+        linkedScoresheetId: input.linkedScoresheetId,
+      })
+      .where(
+        and(
+          eq(sharedScoresheet.id, input.sharedScoresheetId),
+          isNull(sharedScoresheet.linkedScoresheetId),
+        ),
+      )
+      .returning();
+    return updatedSharedScoresheet;
+  }
+
+  public async getScoresheetAnalyticsFamilyRows(args: {
+    input: {
+      userId: string;
+      analyticsGroupingScoresheetId: number;
+      analyticsGroupingScoresheetSourceType: "local" | "shared";
+    };
+    tx?: TransactionType;
+  }) {
+    const { input, tx } = args;
+    const database = tx ?? db;
+    return database
+      .select()
+      .from(vScoresheetAnalyticsForUser)
+      .where(
+        and(
+          eq(vScoresheetAnalyticsForUser.visibleToUserId, input.userId),
+          eq(
+            vScoresheetAnalyticsForUser.analyticsGroupingScoresheetId,
+            input.analyticsGroupingScoresheetId,
+          ),
+          eq(
+            vScoresheetAnalyticsForUser.analyticsGroupingScoresheetSourceType,
+            input.analyticsGroupingScoresheetSourceType,
+          ),
+        ),
+      );
+  }
   public async deleteScoresheet(args: {
     input: {
       id: number;
@@ -321,6 +553,7 @@ class ScoresheetRepository {
       roundsScore?: (typeof scoreSheetRoundsScore)[number];
       targetScore?: number;
       forkedForMatchId?: number | null;
+      forkedFromSharedScoresheetId?: number | null;
     };
     tx?: TransactionType;
   }) {

--- a/packages/api/src/routers/game/game.analytics-link.test.ts
+++ b/packages/api/src/routers/game/game.analytics-link.test.ts
@@ -1,0 +1,359 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+
+import {
+  createFinishedMatchForScoresheet,
+  createGameWithAnalyticsScoresheet,
+  shareFinishedMatchAnalyticsWithRecipient,
+} from "./game.analytics-test-fixtures";
+import {
+  createAuthenticatedCaller,
+  gameTestLifecycle,
+} from "./game-test-fixtures";
+
+describe("Game analytics link router integration", () => {
+  const ownerLifecycle = gameTestLifecycle();
+  const recipientLifecycle = gameTestLifecycle();
+  const thirdUserLifecycle = gameTestLifecycle();
+
+  beforeAll(async () => {
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+    await thirdUserLifecycle.deleteTestUser();
+  });
+
+  afterAll(async () => {
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+    await thirdUserLifecycle.deleteTestUser();
+  });
+
+  beforeEach(async () => {
+    await ownerLifecycle.createTestUser();
+    await recipientLifecycle.createTestUser();
+    await thirdUserLifecycle.createTestUser();
+  });
+
+  afterEach(async () => {
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+    await thirdUserLifecycle.deleteTestUser();
+  });
+
+  const createSharedFixture = async () => {
+    const ownerCaller = await createAuthenticatedCaller(ownerLifecycle.userId);
+
+    const ownerFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
+      gameName: "Analytics Link Source Game",
+    });
+    const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+      gameId: ownerFixture.gameId,
+      scoresheetId: ownerFixture.scoresheetId,
+      matchName: "Analytics Link Source Match",
+    });
+
+    const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+      ownerUserId: ownerLifecycle.userId,
+      recipientUserId: recipientLifecycle.userId,
+      gameId: ownerFixture.gameId,
+      gameScoresheetId: ownerFixture.scoresheetId,
+      matchId: ownerMatch.matchId,
+      matchScoresheetId: ownerMatch.matchScoresheetId,
+    });
+
+    return {
+      ownerFixture,
+      ownerMatch,
+      sharedFixture,
+    };
+  };
+
+  describe("getSharedScoresheetAnalyticsLinkState", () => {
+    test("returns an unlinked scoresheet state by default", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const { sharedFixture } = await createSharedFixture();
+
+      const result =
+        await recipientCaller.game.getSharedScoresheetAnalyticsLinkState({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        });
+
+      expect(result).toMatchObject({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: null,
+        legacyLinkedScoresheetId: null,
+        linkageState: "shared_unlinked",
+      });
+      expect(result.rounds).toEqual(
+        expect.arrayContaining(
+          sharedFixture.sharedGameRounds.map((sharedRound) =>
+            expect.objectContaining({
+              sharedRoundId: sharedRound.id,
+              analyticsLinkedRoundId: null,
+              legacyLinkedRoundId: null,
+              linkageState: "shared_unlinked",
+            }),
+          ),
+        ),
+      );
+    });
+  });
+
+  describe("linkSharedScoresheetAnalytics", () => {
+    test("updates only the analytics link target", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Link Target Game",
+          scoresheetName: "Recipient Link Target Sheet",
+        },
+      );
+      const { sharedFixture } = await createSharedFixture();
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+
+      const result =
+        await recipientCaller.game.getSharedScoresheetAnalyticsLinkState({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        });
+
+      expect(result).toMatchObject({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+        legacyLinkedScoresheetId: null,
+        linkageState: "shared_linked",
+      });
+    });
+
+    test("rejects a non-recipient user", async () => {
+      const thirdUserCaller = await createAuthenticatedCaller(
+        thirdUserLifecycle.userId,
+      );
+      const { sharedFixture } = await createSharedFixture();
+
+      await expect(
+        thirdUserCaller.game.linkSharedScoresheetAnalytics({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+          analyticsLinkedScoresheetId: null,
+        }),
+      ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    });
+
+    test("rejects a local scoresheet from the wrong linked game", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const linkedGameFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Linked Game",
+          scoresheetName: "Recipient Linked Sheet",
+        },
+      );
+      const wrongGameFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Wrong Game",
+          scoresheetName: "Recipient Wrong Sheet",
+        },
+      );
+      const { ownerFixture, ownerMatch } = await createSharedFixture();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: linkedGameFixture.gameId,
+      });
+
+      await expect(
+        recipientCaller.game.linkSharedScoresheetAnalytics({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+          analyticsLinkedScoresheetId: wrongGameFixture.scoresheetId,
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+  });
+
+  describe("linkSharedRoundsAnalytics", () => {
+    test("links shared rounds to rounds from the linked local scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Round Target Game",
+          scoresheetName: "Recipient Round Target Sheet",
+        },
+      );
+      const { ownerFixture, ownerMatch } = await createSharedFixture();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientFixture.gameId,
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+
+      await recipientCaller.game.linkSharedRoundsAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        links: sharedFixture.sharedGameRounds.map((sharedRound, index) => ({
+          sharedRoundId: sharedRound.id,
+          analyticsLinkedRoundId: recipientFixture.rounds[index]?.id ?? null,
+        })),
+      });
+
+      const result =
+        await recipientCaller.game.getSharedScoresheetAnalyticsLinkState({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        });
+
+      expect(result.rounds).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sharedRoundId: sharedFixture.sharedGameRounds[0]?.id,
+            analyticsLinkedRoundId: recipientFixture.rounds[0]?.id,
+            linkageState: "shared_linked",
+          }),
+          expect.objectContaining({
+            sharedRoundId: sharedFixture.sharedGameRounds[1]?.id,
+            analyticsLinkedRoundId: recipientFixture.rounds[1]?.id,
+            linkageState: "shared_linked",
+          }),
+        ]),
+      );
+    });
+
+    test("rejects round linking before the shared scoresheet is linked", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Unlinked Round Game",
+          scoresheetName: "Recipient Unlinked Round Sheet",
+        },
+      );
+      const { sharedFixture } = await createSharedFixture();
+
+      await expect(
+        recipientCaller.game.linkSharedRoundsAnalytics({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+          links: [
+            {
+              sharedRoundId: sharedFixture.sharedGameRounds[0]!.id,
+              analyticsLinkedRoundId: recipientFixture.rounds[0]!.id,
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("rejects a shared round from another shared scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Foreign Shared Round Game",
+          scoresheetName: "Recipient Foreign Shared Round Sheet",
+        },
+      );
+
+      const firstFixture = await createSharedFixture();
+      const secondFixture = await createSharedFixture();
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: firstFixture.sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+
+      await expect(
+        recipientCaller.game.linkSharedRoundsAnalytics({
+          sharedScoresheetId: firstFixture.sharedFixture.sharedGameScoresheetId,
+          links: [
+            {
+              sharedRoundId:
+                secondFixture.sharedFixture.sharedGameRounds[0]!.id,
+              analyticsLinkedRoundId: recipientFixture.rounds[0]!.id,
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("rejects a local round outside the linked local scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Linked Round Parent Game",
+          scoresheetName: "Recipient Linked Round Parent Sheet",
+        },
+      );
+      const wrongRoundFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Wrong Round Game",
+          scoresheetName: "Recipient Wrong Round Sheet",
+        },
+      );
+      const { ownerFixture, ownerMatch } = await createSharedFixture();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientFixture.gameId,
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+
+      await expect(
+        recipientCaller.game.linkSharedRoundsAnalytics({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+          links: [
+            {
+              sharedRoundId: sharedFixture.sharedGameRounds[0]!.id,
+              analyticsLinkedRoundId: wrongRoundFixture.rounds[0]!.id,
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+  });
+});

--- a/packages/api/src/routers/game/game.analytics-link.test.ts
+++ b/packages/api/src/routers/game/game.analytics-link.test.ts
@@ -8,6 +8,7 @@ import {
   test,
 } from "vitest";
 
+import { roundRepository } from "../../repositories/scoresheet/round.repository";
 import {
   createFinishedMatchForScoresheet,
   createGameWithAnalyticsScoresheet,
@@ -190,6 +191,125 @@ describe("Game analytics link router integration", () => {
         }),
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });
+
+    test("clears stale round links when relinking to a different local scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const firstRecipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient First Link Game",
+          scoresheetName: "Recipient First Link Sheet",
+        },
+      );
+      const secondRecipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Second Link Game",
+          scoresheetName: "Recipient Second Link Sheet",
+        },
+      );
+      const { ownerFixture, ownerMatch } = await createSharedFixture();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: firstRecipientFixture.scoresheetId,
+      });
+      await recipientCaller.game.linkSharedRoundsAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        links: sharedFixture.sharedGameRounds.map((sharedRound, index) => ({
+          sharedRoundId: sharedRound.id,
+          analyticsLinkedRoundId:
+            firstRecipientFixture.rounds[index]?.id ?? null,
+        })),
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: secondRecipientFixture.scoresheetId,
+      });
+
+      const result =
+        await recipientCaller.game.getSharedScoresheetAnalyticsLinkState({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        });
+
+      expect(result.analyticsLinkedScoresheetId).toBe(
+        secondRecipientFixture.scoresheetId,
+      );
+      expect(
+        result.rounds.every((round) => round.analyticsLinkedRoundId === null),
+      ).toBe(true);
+      expect(
+        result.rounds.every(
+          (round) => round.linkageState === "shared_unlinked",
+        ),
+      ).toBe(true);
+    });
+
+    test("clears stale round links when unlinking the shared scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Unlink Game",
+          scoresheetName: "Recipient Unlink Sheet",
+        },
+      );
+      const { ownerFixture, ownerMatch } = await createSharedFixture();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientFixture.gameId,
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+      await recipientCaller.game.linkSharedRoundsAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        links: sharedFixture.sharedGameRounds.map((sharedRound, index) => ({
+          sharedRoundId: sharedRound.id,
+          analyticsLinkedRoundId: recipientFixture.rounds[index]?.id ?? null,
+        })),
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: null,
+      });
+
+      const result =
+        await recipientCaller.game.getSharedScoresheetAnalyticsLinkState({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        });
+
+      expect(result.analyticsLinkedScoresheetId).toBeNull();
+      expect(
+        result.rounds.every((round) => round.analyticsLinkedRoundId === null),
+      ).toBe(true);
+      expect(
+        result.rounds.every(
+          (round) => round.linkageState === "shared_unlinked",
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("linkSharedRoundsAnalytics", () => {
@@ -309,6 +429,52 @@ describe("Game analytics link router integration", () => {
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });
 
+    test("rejects duplicate sharedRoundId entries in the request payload", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Duplicate Round Game",
+          scoresheetName: "Recipient Duplicate Round Sheet",
+        },
+      );
+      const { ownerFixture, ownerMatch } = await createSharedFixture();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientFixture.gameId,
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+
+      await expect(
+        recipientCaller.game.linkSharedRoundsAnalytics({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+          links: [
+            {
+              sharedRoundId: sharedFixture.sharedGameRounds[0]!.id,
+              analyticsLinkedRoundId: recipientFixture.rounds[0]!.id,
+            },
+            {
+              sharedRoundId: sharedFixture.sharedGameRounds[0]!.id,
+              analyticsLinkedRoundId: recipientFixture.rounds[1]!.id,
+            },
+          ],
+        }),
+      ).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      });
+    });
+
     test("rejects a local round outside the linked local scoresheet", async () => {
       const recipientCaller = await createAuthenticatedCaller(
         recipientLifecycle.userId,
@@ -352,6 +518,75 @@ describe("Game analytics link router integration", () => {
               analyticsLinkedRoundId: wrongRoundFixture.rounds[0]!.id,
             },
           ],
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("repository rejects linking a shared round from another shared scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Repository Guard Game",
+          scoresheetName: "Recipient Repository Guard Sheet",
+        },
+      );
+
+      const firstFixture = await createSharedFixture();
+      const secondFixture = await createSharedFixture();
+
+      await expect(
+        roundRepository.bulkLinkSharedRoundsAnalytics({
+          input: {
+            sharedScoresheetId:
+              firstFixture.sharedFixture.sharedGameScoresheetId,
+            linkedScoresheetId: recipientFixture.scoresheetId,
+            links: [
+              {
+                sharedRoundId:
+                  secondFixture.sharedFixture.sharedGameRounds[0]!.id,
+                linkedRoundId: recipientFixture.rounds[0]!.id,
+              },
+            ],
+          },
+        }),
+      ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    });
+
+    test("repository rejects linking a round outside the declared local scoresheet", async () => {
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Repository Local Guard Game",
+          scoresheetName: "Recipient Repository Local Guard Sheet",
+        },
+      );
+      const wrongRoundFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Repository Wrong Round Game",
+          scoresheetName: "Recipient Repository Wrong Round Sheet",
+        },
+      );
+      const { sharedFixture } = await createSharedFixture();
+
+      await expect(
+        roundRepository.bulkLinkSharedRoundsAnalytics({
+          input: {
+            sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+            linkedScoresheetId: recipientFixture.scoresheetId,
+            links: [
+              {
+                sharedRoundId: sharedFixture.sharedGameRounds[0]!.id,
+                linkedRoundId: wrongRoundFixture.rounds[0]!.id,
+              },
+            ],
+          },
         }),
       ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     });

--- a/packages/api/src/routers/game/game.analytics-test-fixtures.ts
+++ b/packages/api/src/routers/game/game.analytics-test-fixtures.ts
@@ -1,0 +1,478 @@
+import type { inferProcedureInput } from "@trpc/server";
+
+import { db } from "@board-games/db/client";
+import {
+  match,
+  matchPlayer,
+  player,
+  round,
+  scoresheet,
+  sharedGame,
+  sharedMatch,
+  sharedMatchPlayer,
+  sharedPlayer,
+  sharedScoresheet,
+} from "@board-games/db/schema";
+
+import type { AppRouter } from "../../root";
+import type { TestCaller } from "../../test-fixtures";
+import { createSharedRoundsForScoresheet } from "../../utils/sharing";
+import { createGameFull, createPlayers } from "./game-test-fixtures";
+
+type SharePermission = "view" | "edit";
+
+const assertInserted = <T>(
+  value: T | undefined,
+  message: string,
+): NonNullable<T> => {
+  if (!value) {
+    throw new Error(message);
+  }
+  return value;
+};
+
+export const createGameWithAnalyticsScoresheet = async (
+  caller: TestCaller,
+  options?: {
+    gameName?: string;
+    scoresheetName?: string;
+    isCoop?: boolean;
+  },
+) => {
+  const {
+    gameName = "Analytics Game",
+    scoresheetName = "Analytics Sheet",
+    isCoop = false,
+  } = options ?? {};
+
+  const { gameId, scoresheetId } = await createGameFull(caller, {
+    gameName,
+    scoresheets: [
+      {
+        scoresheet: {
+          name: scoresheetName,
+          winCondition: isCoop ? "Manual" : "Highest Score",
+          roundsScore: "Aggregate",
+          isCoop,
+          targetScore: 0,
+        },
+        rounds: [
+          { name: "Points", type: "Numeric", order: 1, score: 1 },
+          { name: "Bonus", type: "Checkbox", order: 2, score: 1 },
+        ],
+      },
+    ],
+  });
+
+  const scoresheetWithRounds = await db.query.scoresheet.findFirst({
+    where: {
+      id: scoresheetId,
+      deletedAt: {
+        isNull: true,
+      },
+    },
+    with: {
+      rounds: {
+        where: {
+          deletedAt: {
+            isNull: true,
+          },
+        },
+        orderBy: {
+          order: "asc",
+        },
+      },
+    },
+  });
+
+  const insertedScoresheet = assertInserted(
+    scoresheetWithRounds,
+    "Analytics scoresheet fixture was not created.",
+  );
+
+  return {
+    gameId,
+    scoresheetId: insertedScoresheet.id,
+    scoresheetName: insertedScoresheet.name,
+    rounds: insertedScoresheet.rounds,
+  };
+};
+
+export const createFinishedMatchForScoresheet = async (
+  caller: TestCaller,
+  options: {
+    gameId: number;
+    scoresheetId: number;
+    matchName?: string;
+    matchDate?: Date;
+    playerCount?: number;
+    playerPrefix?: string;
+  },
+) => {
+  const {
+    gameId,
+    scoresheetId,
+    matchName = "Analytics Match",
+    matchDate = new Date("2026-03-01T12:00:00.000Z"),
+    playerCount = 2,
+    playerPrefix = "Analytics Player",
+  } = options;
+
+  const players = await createPlayers(caller, playerCount, playerPrefix);
+
+  const matchInput: inferProcedureInput<AppRouter["match"]["createMatch"]> = {
+    name: matchName,
+    date: matchDate,
+    game: { type: "original", id: gameId },
+    scoresheet: { type: "original", id: scoresheetId },
+    players: players.map((createdPlayer) => ({
+      type: "original" as const,
+      id: createdPlayer.id,
+      roles: [],
+      teamId: null,
+    })),
+    teams: [],
+    location: null,
+  };
+
+  const createdMatch = await caller.match.createMatch(matchInput);
+
+  const matchPlayersAndTeams = await caller.match.getMatchPlayersAndTeams({
+    type: "original",
+    id: createdMatch.id,
+  });
+
+  const winningPlayer = assertInserted(
+    matchPlayersAndTeams.players[0],
+    "Match fixture did not create match players.",
+  );
+
+  await caller.match.update.updateMatchManualWinner({
+    match: { type: "original", id: createdMatch.id },
+    winners: [{ id: winningPlayer.baseMatchPlayerId }],
+  });
+
+  const createdMatchRow = await db.query.match.findFirst({
+    where: {
+      id: createdMatch.id,
+    },
+  });
+
+  const createdMatchRecord = assertInserted(
+    createdMatchRow,
+    "Match fixture record was not found after creation.",
+  );
+
+  const createdMatchPlayers = await db.query.matchPlayer.findMany({
+    where: {
+      matchId: createdMatch.id,
+    },
+    orderBy: {
+      id: "asc",
+    },
+  });
+
+  return {
+    matchId: createdMatch.id,
+    matchScoresheetId: createdMatchRecord.scoresheetId,
+    players,
+    matchPlayers: createdMatchPlayers,
+  };
+};
+
+export const shareFinishedMatchAnalyticsWithRecipient = async (options: {
+  ownerUserId: string;
+  recipientUserId: string;
+  gameId: number;
+  gameScoresheetId: number;
+  matchId: number;
+  matchScoresheetId: number;
+  permission?: SharePermission;
+  linkedGameId?: number | null;
+}) => {
+  const {
+    ownerUserId,
+    recipientUserId,
+    gameId,
+    gameScoresheetId,
+    matchId,
+    matchScoresheetId,
+    permission = "view",
+    linkedGameId = null,
+  } = options;
+
+  const matchPlayersWithPlayer = await db.query.matchPlayer.findMany({
+    where: {
+      matchId,
+    },
+    with: {
+      player: true,
+    },
+    orderBy: {
+      id: "asc",
+    },
+  });
+
+  return db.transaction(async (tx) => {
+    const [createdSharedGame] = await tx
+      .insert(sharedGame)
+      .values({
+        ownerId: ownerUserId,
+        sharedWithId: recipientUserId,
+        gameId,
+        linkedGameId,
+        permission,
+      })
+      .returning();
+
+    const sharedGameRow = assertInserted(
+      createdSharedGame,
+      "Shared game fixture was not created.",
+    );
+
+    const [createdGameSharedScoresheet] = await tx
+      .insert(sharedScoresheet)
+      .values({
+        ownerId: ownerUserId,
+        sharedWithId: recipientUserId,
+        scoresheetId: gameScoresheetId,
+        sharedGameId: sharedGameRow.id,
+        permission,
+        type: "game",
+      })
+      .returning();
+
+    const sharedGameScoresheet = assertInserted(
+      createdGameSharedScoresheet,
+      "Game-level shared scoresheet fixture was not created.",
+    );
+
+    const gameScoresheetRounds = await tx.query.round.findMany({
+      where: {
+        scoresheetId: gameScoresheetId,
+        deletedAt: {
+          isNull: true,
+        },
+      },
+      orderBy: {
+        order: "asc",
+      },
+    });
+
+    await createSharedRoundsForScoresheet(
+      tx,
+      gameScoresheetRounds,
+      sharedGameScoresheet.id,
+      ownerUserId,
+      recipientUserId,
+      permission,
+    );
+
+    const [createdMatchSharedScoresheet] = await tx
+      .insert(sharedScoresheet)
+      .values({
+        ownerId: ownerUserId,
+        sharedWithId: recipientUserId,
+        scoresheetId: matchScoresheetId,
+        sharedGameId: sharedGameRow.id,
+        parentId: sharedGameScoresheet.id,
+        permission,
+        type: "match",
+      })
+      .returning();
+
+    const sharedMatchScoresheet = assertInserted(
+      createdMatchSharedScoresheet,
+      "Match-level shared scoresheet fixture was not created.",
+    );
+
+    const insertedSharedPlayers = await Promise.all(
+      matchPlayersWithPlayer.map(async (matchPlayerRow) => {
+        const [createdSharedPlayer] = await tx
+          .insert(sharedPlayer)
+          .values({
+            ownerId: ownerUserId,
+            sharedWithId: recipientUserId,
+            playerId: matchPlayerRow.playerId,
+            permission,
+          })
+          .returning();
+
+        return assertInserted(
+          createdSharedPlayer,
+          `Shared player fixture was not created for owner player ${String(matchPlayerRow.playerId)}.`,
+        );
+      }),
+    );
+
+    const sharedPlayerIdByPlayerId = new Map(
+      insertedSharedPlayers.map((sharedPlayerRow) => [
+        sharedPlayerRow.playerId,
+        sharedPlayerRow.id,
+      ]),
+    );
+
+    const [createdSharedMatch] = await tx
+      .insert(sharedMatch)
+      .values({
+        ownerId: ownerUserId,
+        sharedWithId: recipientUserId,
+        matchId,
+        sharedGameId: sharedGameRow.id,
+        sharedScoresheetId: sharedMatchScoresheet.id,
+        permission,
+      })
+      .returning();
+
+    const sharedMatchRow = assertInserted(
+      createdSharedMatch,
+      "Shared match fixture was not created.",
+    );
+
+    const insertedSharedMatchPlayers = await Promise.all(
+      matchPlayersWithPlayer.map(async (matchPlayerRow) => {
+        const [createdSharedMatchPlayer] = await tx
+          .insert(sharedMatchPlayer)
+          .values({
+            ownerId: ownerUserId,
+            sharedWithId: recipientUserId,
+            matchPlayerId: matchPlayerRow.id,
+            sharedMatchId: sharedMatchRow.id,
+            sharedPlayerId:
+              sharedPlayerIdByPlayerId.get(matchPlayerRow.playerId) ?? null,
+            permission,
+          })
+          .returning();
+
+        return assertInserted(
+          createdSharedMatchPlayer,
+          `Shared match player fixture was not created for match player ${String(matchPlayerRow.id)}.`,
+        );
+      }),
+    );
+
+    const sharedGameRounds = await tx.query.sharedRound.findMany({
+      where: {
+        sharedScoresheetId: sharedGameScoresheet.id,
+      },
+      with: {
+        round: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+
+    return {
+      sharedGameId: sharedGameRow.id,
+      sharedGameScoresheetId: sharedGameScoresheet.id,
+      sharedGameRounds,
+      sharedMatchId: sharedMatchRow.id,
+      sharedMatchScoresheetId: sharedMatchScoresheet.id,
+      sharedPlayers: insertedSharedPlayers,
+      sharedMatchPlayers: insertedSharedMatchPlayers,
+    };
+  });
+};
+
+export const getScoresheetById = async (scoresheetId: number) => {
+  return db.query.scoresheet.findFirst({
+    where: {
+      id: scoresheetId,
+    },
+    with: {
+      rounds: {
+        where: {
+          deletedAt: {
+            isNull: true,
+          },
+        },
+        orderBy: {
+          order: "asc",
+        },
+      },
+    },
+  });
+};
+
+export const getSharedScoresheetById = async (sharedScoresheetId: number) => {
+  return db.query.sharedScoresheet.findFirst({
+    where: {
+      id: sharedScoresheetId,
+    },
+    with: {
+      sharedRounds: {
+        with: {
+          round: true,
+        },
+        orderBy: {
+          id: "asc",
+        },
+      },
+    },
+  });
+};
+
+export const getMatchById = async (matchId: number) => {
+  return db.query.match.findFirst({
+    where: {
+      id: matchId,
+    },
+  });
+};
+
+export const getLocalOriginalScoresheetsForUser = async (options: {
+  userId: string;
+  gameId: number;
+}) => {
+  return db.query.scoresheet.findMany({
+    where: {
+      createdBy: options.userId,
+      gameId: options.gameId,
+      deletedAt: {
+        isNull: true,
+      },
+      type: {
+        OR: [{ eq: "Game" }, { eq: "Default" }],
+      },
+    },
+    with: {
+      rounds: {
+        where: {
+          deletedAt: {
+            isNull: true,
+          },
+        },
+        orderBy: {
+          order: "asc",
+        },
+      },
+    },
+    orderBy: {
+      id: "asc",
+    },
+  });
+};
+
+export const getSharedMatchById = async (sharedMatchId: number) => {
+  return db.query.sharedMatch.findFirst({
+    where: {
+      id: sharedMatchId,
+    },
+  });
+};
+
+export const getSharedPlayersForRecipient = async (options: {
+  ownerUserId: string;
+  recipientUserId: string;
+}) => {
+  return db.query.sharedPlayer.findMany({
+    where: {
+      ownerId: options.ownerUserId,
+      sharedWithId: options.recipientUserId,
+    },
+    orderBy: {
+      id: "asc",
+    },
+  });
+};

--- a/packages/api/src/routers/game/game.analytics-test-fixtures.ts
+++ b/packages/api/src/routers/game/game.analytics-test-fixtures.ts
@@ -2,11 +2,6 @@ import type { inferProcedureInput } from "@trpc/server";
 
 import { db } from "@board-games/db/client";
 import {
-  match,
-  matchPlayer,
-  player,
-  round,
-  scoresheet,
   sharedGame,
   sharedMatch,
   sharedMatchPlayer,
@@ -286,24 +281,24 @@ export const shareFinishedMatchAnalyticsWithRecipient = async (options: {
       "Match-level shared scoresheet fixture was not created.",
     );
 
-    const insertedSharedPlayers = await Promise.all(
-      matchPlayersWithPlayer.map(async (matchPlayerRow) => {
-        const [createdSharedPlayer] = await tx
-          .insert(sharedPlayer)
-          .values({
-            ownerId: ownerUserId,
-            sharedWithId: recipientUserId,
-            playerId: matchPlayerRow.playerId,
-            permission,
-          })
-          .returning();
+    const insertedSharedPlayers = await tx
+      .insert(sharedPlayer)
+      .values(
+        matchPlayersWithPlayer.map((matchPlayerRow) => ({
+          ownerId: ownerUserId,
+          sharedWithId: recipientUserId,
+          playerId: matchPlayerRow.playerId,
+          permission,
+        })),
+      )
+      .returning();
 
-        return assertInserted(
-          createdSharedPlayer,
-          `Shared player fixture was not created for owner player ${String(matchPlayerRow.playerId)}.`,
-        );
-      }),
-    );
+    insertedSharedPlayers.forEach((sharedPlayerRow) => {
+      assertInserted(
+        sharedPlayerRow,
+        `Shared player fixture was not created for owner player ${String(sharedPlayerRow.playerId)}.`,
+      );
+    });
 
     const sharedPlayerIdByPlayerId = new Map(
       insertedSharedPlayers.map((sharedPlayerRow) => [
@@ -329,27 +324,27 @@ export const shareFinishedMatchAnalyticsWithRecipient = async (options: {
       "Shared match fixture was not created.",
     );
 
-    const insertedSharedMatchPlayers = await Promise.all(
-      matchPlayersWithPlayer.map(async (matchPlayerRow) => {
-        const [createdSharedMatchPlayer] = await tx
-          .insert(sharedMatchPlayer)
-          .values({
-            ownerId: ownerUserId,
-            sharedWithId: recipientUserId,
-            matchPlayerId: matchPlayerRow.id,
-            sharedMatchId: sharedMatchRow.id,
-            sharedPlayerId:
-              sharedPlayerIdByPlayerId.get(matchPlayerRow.playerId) ?? null,
-            permission,
-          })
-          .returning();
+    const insertedSharedMatchPlayers = await tx
+      .insert(sharedMatchPlayer)
+      .values(
+        matchPlayersWithPlayer.map((matchPlayerRow) => ({
+          ownerId: ownerUserId,
+          sharedWithId: recipientUserId,
+          matchPlayerId: matchPlayerRow.id,
+          sharedMatchId: sharedMatchRow.id,
+          sharedPlayerId:
+            sharedPlayerIdByPlayerId.get(matchPlayerRow.playerId) ?? null,
+          permission,
+        })),
+      )
+      .returning();
 
-        return assertInserted(
-          createdSharedMatchPlayer,
-          `Shared match player fixture was not created for match player ${String(matchPlayerRow.id)}.`,
-        );
-      }),
-    );
+    insertedSharedMatchPlayers.forEach((sharedMatchPlayerRow) => {
+      assertInserted(
+        sharedMatchPlayerRow,
+        `Shared match player fixture was not created for match player ${String(sharedMatchPlayerRow.matchPlayerId)}.`,
+      );
+    });
 
     const sharedGameRounds = await tx.query.sharedRound.findMany({
       where: {
@@ -433,7 +428,7 @@ export const getLocalOriginalScoresheetsForUser = async (options: {
         isNull: true,
       },
       type: {
-        OR: [{ eq: "Game" }, { eq: "Default" }],
+        in: ["Game", "Default"],
       },
     },
     with: {

--- a/packages/api/src/routers/game/game.input.ts
+++ b/packages/api/src/routers/game/game.input.ts
@@ -37,12 +37,20 @@ export type LinkSharedScoresheetAnalyticsInputType = z.infer<
 
 export const linkSharedRoundsAnalyticsInput = z.object({
   sharedScoresheetId: z.number(),
-  links: z.array(
-    z.object({
-      sharedRoundId: z.number(),
-      analyticsLinkedRoundId: z.number().nullable(),
-    }),
-  ),
+  links: z
+    .array(
+      z.object({
+        sharedRoundId: z.number(),
+        analyticsLinkedRoundId: z.number().nullable(),
+      }),
+    )
+    .refine(
+      (links) =>
+        new Set(links.map((link) => link.sharedRoundId)).size === links.length,
+      {
+        message: "duplicate sharedRoundId in links",
+      },
+    ),
 });
 export type LinkSharedRoundsAnalyticsInputType = z.infer<
   typeof linkSharedRoundsAnalyticsInput

--- a/packages/api/src/routers/game/game.input.ts
+++ b/packages/api/src/routers/game/game.input.ts
@@ -20,6 +20,34 @@ export const getGameInput = z.discriminatedUnion("type", [
 
 export type GetGameInputType = z.infer<typeof getGameInput>;
 
+export const getSharedScoresheetAnalyticsLinkStateInput = z.object({
+  sharedScoresheetId: z.number(),
+});
+export type GetSharedScoresheetAnalyticsLinkStateInputType = z.infer<
+  typeof getSharedScoresheetAnalyticsLinkStateInput
+>;
+
+export const linkSharedScoresheetAnalyticsInput = z.object({
+  sharedScoresheetId: z.number(),
+  analyticsLinkedScoresheetId: z.number().nullable(),
+});
+export type LinkSharedScoresheetAnalyticsInputType = z.infer<
+  typeof linkSharedScoresheetAnalyticsInput
+>;
+
+export const linkSharedRoundsAnalyticsInput = z.object({
+  sharedScoresheetId: z.number(),
+  links: z.array(
+    z.object({
+      sharedRoundId: z.number(),
+      analyticsLinkedRoundId: z.number().nullable(),
+    }),
+  ),
+});
+export type LinkSharedRoundsAnalyticsInputType = z.infer<
+  typeof linkSharedRoundsAnalyticsInput
+>;
+
 export const createGameInput = z.object({
   game: insertGameSchema
     .pick({

--- a/packages/api/src/routers/game/game.output.contracts.test.ts
+++ b/packages/api/src/routers/game/game.output.contracts.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getGameScoresheetStatsOutput,
+  getSharedScoresheetAnalyticsLinkStateOutput,
+} from "./game.output";
+
+describe("game router output contracts", () => {
+  test("getGameScoresheetStatsOutput accepts original and shared analytics families", () => {
+    const parsed = getGameScoresheetStatsOutput.safeParse([
+      {
+        type: "original",
+        id: 10,
+        name: "Local Analytics Sheet",
+        isCoop: false,
+        winCondition: "Highest Score",
+        roundsScore: "Aggregate",
+        targetScore: 0,
+        isDefault: false,
+        plays: 2,
+        avgScore: 18.5,
+        winningAvgScore: 22,
+        analyticsGroupingScoresheetId: 10,
+        analyticsGroupingScoresheetSourceType: "local",
+        analyticsGroupingKey: "local:10",
+        linkageState: "original",
+        contributingVisibleScoresheets: [
+          {
+            visibleScoresheetId: 10,
+            visibleScoresheetSourceType: "local",
+            name: "Local Analytics Sheet",
+            matchCount: 2,
+          },
+        ],
+        contributingMatchCount: 2,
+        players: [
+          {
+            type: "original",
+            playerId: 1,
+            name: "Alice",
+            numMatches: 2,
+            wins: 1,
+            winRate: 0.5,
+            avgScore: 20,
+            bestScore: 24,
+            worstScore: 16,
+            image: null,
+            isUser: false,
+            scores: [
+              {
+                date: new Date("2026-03-01T12:00:00.000Z"),
+                score: 24,
+                isWin: true,
+              },
+            ],
+          },
+        ],
+        rounds: [
+          {
+            id: 101,
+            name: "Points",
+            type: "Numeric",
+            order: 1,
+            score: 1,
+            color: null,
+            lookup: null,
+            modifier: null,
+            avgScore: 14,
+            volatility: 3,
+            winningAvgScore: 18,
+            checkRate: null,
+            winningCheckRate: null,
+            players: [],
+          },
+        ],
+      },
+      {
+        type: "shared",
+        sharedId: 22,
+        permission: "view",
+        name: "Shared Analytics Sheet",
+        isCoop: false,
+        winCondition: "Highest Score",
+        roundsScore: "Aggregate",
+        targetScore: 0,
+        isDefault: false,
+        plays: 1,
+        avgScore: null,
+        winningAvgScore: null,
+        analyticsGroupingScoresheetId: 22,
+        analyticsGroupingScoresheetSourceType: "shared",
+        analyticsGroupingKey: "shared:22",
+        linkageState: "shared_unlinked",
+        contributingVisibleScoresheets: [
+          {
+            visibleScoresheetId: 22,
+            visibleScoresheetSourceType: "shared",
+            name: "Shared Analytics Sheet",
+            matchCount: 1,
+          },
+        ],
+        contributingMatchCount: 1,
+        players: [
+          {
+            type: "shared",
+            sharedId: 7,
+            name: "Bob",
+            numMatches: 1,
+            wins: 0,
+            winRate: 0,
+            avgScore: null,
+            bestScore: null,
+            worstScore: null,
+            image: null,
+            isUser: false,
+            scores: [
+              {
+                date: new Date("2026-03-02T12:00:00.000Z"),
+                score: null,
+                isWin: false,
+              },
+            ],
+          },
+        ],
+        rounds: [
+          {
+            id: 202,
+            name: "Bonus",
+            type: "Checkbox",
+            order: 2,
+            score: 1,
+            color: null,
+            lookup: null,
+            modifier: null,
+            avgScore: null,
+            volatility: null,
+            winningAvgScore: null,
+            checkRate: 50,
+            winningCheckRate: 100,
+            players: [],
+          },
+        ],
+      },
+    ]);
+
+    expect(parsed.success).toBe(true);
+  });
+
+  test("getSharedScoresheetAnalyticsLinkStateOutput accepts mixed linked and unlinked rounds", () => {
+    const parsed = getSharedScoresheetAnalyticsLinkStateOutput.safeParse({
+      sharedScoresheetId: 5,
+      analyticsLinkedScoresheetId: 10,
+      legacyLinkedScoresheetId: 10,
+      linkageState: "shared_linked",
+      rounds: [
+        {
+          sharedRoundId: 50,
+          roundId: 500,
+          roundName: "Points",
+          analyticsLinkedRoundId: 1000,
+          legacyLinkedRoundId: 1000,
+          linkageState: "shared_linked",
+        },
+        {
+          sharedRoundId: 51,
+          roundId: 501,
+          roundName: "Bonus",
+          analyticsLinkedRoundId: null,
+          legacyLinkedRoundId: 1001,
+          linkageState: "shared_unlinked",
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/packages/api/src/routers/game/game.output.ts
+++ b/packages/api/src/routers/game/game.output.ts
@@ -400,6 +400,13 @@ export type GetGameScoresheetStatsRoundSchemaType = z.infer<
   typeof getGameScoresheetStatsRoundSchema
 >;
 
+const contributingVisibleScoresheetSchema = z.object({
+  visibleScoresheetId: z.number(),
+  visibleScoresheetSourceType: z.enum(["local", "shared"]),
+  name: z.string(),
+  matchCount: z.number(),
+});
+
 export const getGameScoresheetStatsOutput = z.array(
   z.discriminatedUnion("type", [
     scoreSheetSchema.safeExtend({
@@ -412,6 +419,14 @@ export const getGameScoresheetStatsOutput = z.array(
       avgScore: z.number().nullable(),
       /** Average final score when the result was a win. */
       winningAvgScore: z.number().nullable(),
+      analyticsGroupingScoresheetId: z.number(),
+      analyticsGroupingScoresheetSourceType: z.enum(["local", "shared"]),
+      analyticsGroupingKey: z.string(),
+      linkageState: z.enum(["original", "shared_unlinked", "shared_linked"]),
+      contributingVisibleScoresheets: z.array(
+        contributingVisibleScoresheetSchema,
+      ),
+      contributingMatchCount: z.number(),
       /** Overall stats per player (match count, wins, final scores). */
       players: z.array(getGameScoresheetStatsOverallPlayerSchema),
       rounds: z.array(getGameScoresheetStatsRoundSchema),
@@ -427,6 +442,14 @@ export const getGameScoresheetStatsOutput = z.array(
       avgScore: z.number().nullable(),
       /** Average final score when the result was a win. */
       winningAvgScore: z.number().nullable(),
+      analyticsGroupingScoresheetId: z.number(),
+      analyticsGroupingScoresheetSourceType: z.enum(["local", "shared"]),
+      analyticsGroupingKey: z.string(),
+      linkageState: z.enum(["original", "shared_unlinked", "shared_linked"]),
+      contributingVisibleScoresheets: z.array(
+        contributingVisibleScoresheetSchema,
+      ),
+      contributingMatchCount: z.number(),
       /** Overall stats per player (match count, wins, final scores). */
       players: z.array(getGameScoresheetStatsOverallPlayerSchema),
       rounds: z.array(getGameScoresheetStatsRoundSchema),
@@ -435,6 +458,36 @@ export const getGameScoresheetStatsOutput = z.array(
 );
 export type GetGameScoresheetStatsOutputType = z.infer<
   typeof getGameScoresheetStatsOutput
+>;
+
+export const getSharedScoresheetAnalyticsLinkStateOutput = z.object({
+  sharedScoresheetId: z.number(),
+  analyticsLinkedScoresheetId: z.number().nullable(),
+  legacyLinkedScoresheetId: z.number().nullable(),
+  linkageState: z.enum(["shared_unlinked", "shared_linked"]),
+  rounds: z.array(
+    z.object({
+      sharedRoundId: z.number(),
+      roundId: z.number(),
+      roundName: z.string(),
+      analyticsLinkedRoundId: z.number().nullable(),
+      legacyLinkedRoundId: z.number().nullable(),
+      linkageState: z.enum(["shared_unlinked", "shared_linked"]),
+    }),
+  ),
+});
+export type GetSharedScoresheetAnalyticsLinkStateOutputType = z.infer<
+  typeof getSharedScoresheetAnalyticsLinkStateOutput
+>;
+
+export const linkSharedScoresheetAnalyticsOutput = z.void();
+export type LinkSharedScoresheetAnalyticsOutputType = z.infer<
+  typeof linkSharedScoresheetAnalyticsOutput
+>;
+
+export const linkSharedRoundsAnalyticsOutput = z.void();
+export type LinkSharedRoundsAnalyticsOutputType = z.infer<
+  typeof linkSharedRoundsAnalyticsOutput
 >;
 
 // ─── Game Insights (extracted to game-insights.output.ts) ────────

--- a/packages/api/src/routers/game/game.router.ts
+++ b/packages/api/src/routers/game/game.router.ts
@@ -2,6 +2,7 @@ import type { TRPCRouterRecord } from "@trpc/server";
 import { z } from "zod/v4";
 
 import { gameEditService } from "../../services/game/game-edit.service";
+import { gameAnalyticsLinkService } from "../../services/game/game-analytics-link.service";
 import { gameImportService } from "../../services/game/game-import.service";
 import { gameInsightsService } from "../../services/game/game-insights.service";
 import { gameListService } from "../../services/game/game-list.service";
@@ -14,7 +15,10 @@ import {
   createGameInput,
   editGameInput,
   getGameInput,
+  getSharedScoresheetAnalyticsLinkStateInput,
   importBGGGamesInput,
+  linkSharedRoundsAnalyticsInput,
+  linkSharedScoresheetAnalyticsInput,
 } from "./game.input";
 import {
   createGameOutput,
@@ -31,7 +35,10 @@ import {
   getGamesOutput,
   getGameStatsHeaderOutput,
   getGameToShareOutput,
+  getSharedScoresheetAnalyticsLinkStateOutput,
   importBGGGamesOutput,
+  linkSharedRoundsAnalyticsOutput,
+  linkSharedScoresheetAnalyticsOutput,
 } from "./game.output";
 
 export const gameRouter = {
@@ -145,6 +152,33 @@ export const gameRouter = {
     .output(getGameScoresheetStatsOutput)
     .query(async ({ ctx, input }) => {
       return gameStatsService.getGameScoresheetStats({
+        ctx,
+        input,
+      });
+    }),
+  getSharedScoresheetAnalyticsLinkState: protectedUserProcedure
+    .input(getSharedScoresheetAnalyticsLinkStateInput)
+    .output(getSharedScoresheetAnalyticsLinkStateOutput)
+    .query(async ({ ctx, input }) => {
+      return gameAnalyticsLinkService.getSharedScoresheetAnalyticsLinkState({
+        ctx,
+        input,
+      });
+    }),
+  linkSharedScoresheetAnalytics: protectedUserProcedure
+    .input(linkSharedScoresheetAnalyticsInput)
+    .output(linkSharedScoresheetAnalyticsOutput)
+    .mutation(async ({ ctx, input }) => {
+      await gameAnalyticsLinkService.linkSharedScoresheetAnalytics({
+        ctx,
+        input,
+      });
+    }),
+  linkSharedRoundsAnalytics: protectedUserProcedure
+    .input(linkSharedRoundsAnalyticsInput)
+    .output(linkSharedRoundsAnalyticsOutput)
+    .mutation(async ({ ctx, input }) => {
+      await gameAnalyticsLinkService.linkSharedRoundsAnalytics({
         ctx,
         input,
       });

--- a/packages/api/src/routers/game/game.stats.test.ts
+++ b/packages/api/src/routers/game/game.stats.test.ts
@@ -9,229 +9,553 @@ import {
 } from "vitest";
 
 import {
+  createFinishedMatchForScoresheet,
+  createGameWithAnalyticsScoresheet,
+  shareFinishedMatchAnalyticsWithRecipient,
+} from "./game.analytics-test-fixtures";
+import {
   createAuthenticatedCaller,
-  createGameWithFinishedMatch,
-  createGameWithScoresheet,
   ensureUserPlayer,
   gameTestLifecycle,
 } from "./game-test-fixtures";
 
-describe("Game Stats Tests (header, playerStats, scoresheetStats)", () => {
-  const lifecycle = gameTestLifecycle();
+describe("Game stats router analytics integration", () => {
+  const ownerLifecycle = gameTestLifecycle();
+  const recipientLifecycle = gameTestLifecycle();
+  const recipientBLifecycle = gameTestLifecycle();
 
   beforeAll(async () => {
-    await lifecycle.deleteTestUser();
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+    await recipientBLifecycle.deleteTestUser();
   });
 
   afterAll(async () => {
-    await lifecycle.deleteTestUser();
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+    await recipientBLifecycle.deleteTestUser();
   });
 
   beforeEach(async () => {
-    await lifecycle.createTestUser();
+    await ownerLifecycle.createTestUser();
+    await recipientLifecycle.createTestUser();
+    await recipientBLifecycle.createTestUser();
   });
 
   afterEach(async () => {
-    await lifecycle.deleteTestUser();
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+    await recipientBLifecycle.deleteTestUser();
   });
 
-  // ── getGameStatsHeader ───────────────────────────────────────────────
-
-  describe("game.getGameStatsHeader", () => {
-    test("returns default stats for game with no matches", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      await ensureUserPlayer(caller);
-      const { gameId } = await createGameWithScoresheet(
-        caller,
-        "No Match Stats Game",
+  describe("game.getGameStatsHeader shared visibility behavior", () => {
+    test("includes shared matches for a recipient without analytics linking", async () => {
+      const ownerCaller = await createAuthenticatedCaller(
+        ownerLifecycle.userId,
+      );
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
       );
 
-      const result = await caller.game.getGameStatsHeader({
-        type: "original",
-        id: gameId,
-      });
+      await ensureUserPlayer(recipientCaller);
 
-      expect(result).toBeDefined();
-      expect(typeof result.winRate).toBe("number");
-      expect(typeof result.avgPlaytime).toBe("number");
-      expect(typeof result.totalPlaytime).toBe("number");
-      expect(typeof result.userTotalPlaytime).toBe("number");
-      expect(typeof result.userAvgPlaytime).toBe("number");
-      expect(typeof result.overallMatchesPlayed).toBe("number");
-      expect(typeof result.userMatchesPlayed).toBe("number");
-      expect(result.overallMatchesPlayed).toBe(0);
-    });
-
-    test("returns stats for game with finished match", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      await ensureUserPlayer(caller);
-      const { gameId } = await createGameWithFinishedMatch(caller, {
-        gameName: "Stats Game",
-        matchName: "Stats Match",
-      });
-
-      const result = await caller.game.getGameStatsHeader({
-        type: "original",
-        id: gameId,
-      });
-
-      expect(result.overallMatchesPlayed).toBeGreaterThanOrEqual(1);
-      expect(typeof result.winRate).toBe("number");
-      expect(typeof result.avgPlaytime).toBe("number");
-    });
-
-    test("throws for user without player record", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      const { gameId } = await createGameWithScoresheet(
-        caller,
-        "No Player Stats Game",
+      const ownerFixture = await createGameWithAnalyticsScoresheet(
+        ownerCaller,
+        {
+          gameName: "Shared Header Game",
+        },
       );
+      const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+        gameId: ownerFixture.gameId,
+        scoresheetId: ownerFixture.scoresheetId,
+        matchName: "Shared Header Match",
+      });
 
-      // Without ensureUserPlayer, this should throw "Current user not found"
-      await expect(
-        caller.game.getGameStatsHeader({ type: "original", id: gameId }),
-      ).rejects.toThrow();
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+      });
+
+      const header = await recipientCaller.game.getGameStatsHeader({
+        type: "shared",
+        sharedGameId: sharedFixture.sharedGameId,
+      });
+
+      expect(header.overallMatchesPlayed).toBe(1);
+      expect(header.userMatchesPlayed).toBe(0);
+      expect(header.winRate).toBe(0);
     });
   });
 
-  // ── getGamePlayerStats ───────────────────────────────────────────────
-
-  describe("game.getGamePlayerStats", () => {
-    test("returns empty players for game with no matches", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      const { gameId } = await createGameWithScoresheet(
-        caller,
-        "No Players Stats Game",
+  describe("game.getGamePlayerStats shared visibility behavior", () => {
+    test("returns shared players for a visible shared match", async () => {
+      const ownerCaller = await createAuthenticatedCaller(
+        ownerLifecycle.userId,
+      );
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
       );
 
-      const result = await caller.game.getGamePlayerStats({
-        type: "original",
-        id: gameId,
-      });
-
-      expect(result).toBeDefined();
-      expect(result.players).toBeDefined();
-      expect(Array.isArray(result.players)).toBe(true);
-      expect(result.players).toHaveLength(0);
-    });
-
-    test("returns player stats for game with finished match", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      const { gameId, players } = await createGameWithFinishedMatch(caller, {
-        gameName: "Player Stats Game",
-        matchName: "Player Stats Match",
+      const ownerFixture = await createGameWithAnalyticsScoresheet(
+        ownerCaller,
+        {
+          gameName: "Shared Player Stats Game",
+        },
+      );
+      const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+        gameId: ownerFixture.gameId,
+        scoresheetId: ownerFixture.scoresheetId,
+        matchName: "Shared Player Stats Match",
         playerCount: 3,
       });
 
-      const result = await caller.game.getGamePlayerStats({
-        type: "original",
-        id: gameId,
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
       });
 
-      expect(result.players.length).toBeGreaterThanOrEqual(players.length);
+      const playerStats = await recipientCaller.game.getGamePlayerStats({
+        type: "shared",
+        sharedGameId: sharedFixture.sharedGameId,
+      });
 
-      // Verify player stat shape
-      const stat = result.players[0];
-      expect(stat).toBeDefined();
-      if (stat) {
-        expect(stat.name).toBeDefined();
-        expect(typeof stat.coopMatches).toBe("number");
-        expect(typeof stat.competitiveMatches).toBe("number");
-        expect(typeof stat.coopWins).toBe("number");
-        expect(typeof stat.competitiveWins).toBe("number");
-        expect(typeof stat.coopWinRate).toBe("number");
-        expect(typeof stat.competitiveWinRate).toBe("number");
-      }
-    });
-
-    test("throws for non-existent game", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-
-      // Consistent with getGameScoresheetStats: both throw NOT_FOUND
-      // for non-existent games rather than returning empty results
-      await expect(
-        caller.game.getGamePlayerStats({
-          type: "original",
-          id: 999999,
-        }),
-      ).rejects.toThrow();
+      expect(playerStats.players).toHaveLength(3);
+      expect(
+        playerStats.players.every((player) => player.type === "shared"),
+      ).toBe(true);
+      expect(playerStats.players.map((player) => player.name).sort()).toEqual(
+        ownerMatch.players.map((player) => player.name).sort(),
+      );
     });
   });
 
-  // ── getGameScoresheetStats ───────────────────────────────────────────
+  describe("game.getGameScoresheetStats analytics family behavior", () => {
+    test("keeps original-only stats in a local analytics family", async () => {
+      const caller = await createAuthenticatedCaller(ownerLifecycle.userId);
+      await ensureUserPlayer(caller);
 
-  describe("game.getGameScoresheetStats", () => {
-    test("returns empty scoresheet stats for game with no matches", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      const { gameId } = await createGameWithScoresheet(
-        caller,
-        "No Match SS Stats Game",
+      const gameFixture = await createGameWithAnalyticsScoresheet(caller, {
+        gameName: "Original Analytics Game",
+      });
+      const finishedMatch = await createFinishedMatchForScoresheet(caller, {
+        gameId: gameFixture.gameId,
+        scoresheetId: gameFixture.scoresheetId,
+        matchName: "Original Analytics Match",
+      });
+
+      const header = await caller.game.getGameStatsHeader({
+        type: "original",
+        id: gameFixture.gameId,
+      });
+      const playerStats = await caller.game.getGamePlayerStats({
+        type: "original",
+        id: gameFixture.gameId,
+      });
+      const scoresheetStats = await caller.game.getGameScoresheetStats({
+        type: "original",
+        id: gameFixture.gameId,
+      });
+
+      expect(header.overallMatchesPlayed).toBe(1);
+      expect(playerStats.players.map((player) => player.name).sort()).toEqual(
+        finishedMatch.players.map((player) => player.name).sort(),
+      );
+      expect(scoresheetStats).toHaveLength(1);
+
+      const [family] = scoresheetStats;
+      expect(family).toMatchObject({
+        type: "original",
+        id: gameFixture.scoresheetId,
+        analyticsGroupingScoresheetId: gameFixture.scoresheetId,
+        analyticsGroupingScoresheetSourceType: "local",
+        linkageState: "original",
+        contributingMatchCount: 1,
+      });
+      expect(family?.analyticsGroupingKey).toBe(
+        `local:${String(gameFixture.scoresheetId)}`,
+      );
+    });
+
+    test("keeps a shared unlinked scoresheet in its own shared analytics family", async () => {
+      const ownerCaller = await createAuthenticatedCaller(
+        ownerLifecycle.userId,
+      );
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
       );
 
-      const result = await caller.game.getGameScoresheetStats({
-        type: "original",
-        id: gameId,
+      await ensureUserPlayer(recipientCaller);
+
+      const ownerFixture = await createGameWithAnalyticsScoresheet(
+        ownerCaller,
+        {
+          gameName: "Shared Unlinked Game",
+        },
+      );
+      const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+        gameId: ownerFixture.gameId,
+        scoresheetId: ownerFixture.scoresheetId,
+        matchName: "Shared Unlinked Match",
       });
 
-      expect(Array.isArray(result)).toBe(true);
-      // No finished matches means no scoresheet stats are returned
-      expect(result).toHaveLength(0);
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+      });
+
+      const header = await recipientCaller.game.getGameStatsHeader({
+        type: "shared",
+        sharedGameId: sharedFixture.sharedGameId,
+      });
+      const playerStats = await recipientCaller.game.getGamePlayerStats({
+        type: "shared",
+        sharedGameId: sharedFixture.sharedGameId,
+      });
+      const scoresheetStats = await recipientCaller.game.getGameScoresheetStats(
+        {
+          type: "shared",
+          sharedGameId: sharedFixture.sharedGameId,
+        },
+      );
+
+      expect(header.overallMatchesPlayed).toBe(1);
+      expect(playerStats.players).toHaveLength(2);
+      expect(scoresheetStats).toHaveLength(1);
+
+      const [family] = scoresheetStats;
+      expect(family).toMatchObject({
+        type: "shared",
+        sharedId: sharedFixture.sharedGameScoresheetId,
+        analyticsGroupingScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsGroupingScoresheetSourceType: "shared",
+        linkageState: "shared_unlinked",
+        contributingMatchCount: 1,
+      });
+      expect(family?.analyticsGroupingKey).toBe(
+        `shared:${String(sharedFixture.sharedGameScoresheetId)}`,
+      );
+      expect(family?.contributingVisibleScoresheets).toHaveLength(1);
+      expect(family?.contributingVisibleScoresheets[0]).toMatchObject({
+        visibleScoresheetId: sharedFixture.sharedGameScoresheetId,
+        visibleScoresheetSourceType: "shared",
+        matchCount: 1,
+      });
     });
 
-    test("returns scoresheet stats for game with finished match", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      const { gameId } = await createGameWithFinishedMatch(caller, {
-        gameName: "SS Stats Game",
-        matchName: "SS Stats Match",
+    test("merges a shared scoresheet into a linked local analytics family", async () => {
+      const ownerCaller = await createAuthenticatedCaller(
+        ownerLifecycle.userId,
+      );
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+
+      await ensureUserPlayer(recipientCaller);
+
+      const ownerFixture = await createGameWithAnalyticsScoresheet(
+        ownerCaller,
+        {
+          gameName: "Shared Linked Source Game",
+        },
+      );
+      const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+        gameId: ownerFixture.gameId,
+        scoresheetId: ownerFixture.scoresheetId,
+        matchName: "Shared Linked Source Match",
       });
 
-      const result = await caller.game.getGameScoresheetStats({
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Linked Game",
+          scoresheetName: "Recipient Analytics Sheet",
+        },
+      );
+
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientFixture.gameId,
+      });
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+      await recipientCaller.game.linkSharedRoundsAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        links: sharedFixture.sharedGameRounds.map((sharedRound, index) => ({
+          sharedRoundId: sharedRound.id,
+          analyticsLinkedRoundId: recipientFixture.rounds[index]?.id ?? null,
+        })),
+      });
+
+      const scoresheetStats = await recipientCaller.game.getGameScoresheetStats(
+        {
+          type: "shared",
+          sharedGameId: sharedFixture.sharedGameId,
+        },
+      );
+
+      expect(scoresheetStats).toHaveLength(1);
+
+      const [family] = scoresheetStats;
+      expect(family).toMatchObject({
         type: "original",
-        id: gameId,
+        id: recipientFixture.scoresheetId,
+        analyticsGroupingScoresheetId: recipientFixture.scoresheetId,
+        analyticsGroupingScoresheetSourceType: "local",
+        linkageState: "shared_linked",
+        contributingMatchCount: 1,
       });
-
-      expect(result.length).toBeGreaterThanOrEqual(1);
-      const ss = result[0];
-      expect(ss).toBeDefined();
-      if (ss) {
-        expect(ss.plays).toBeGreaterThanOrEqual(1);
-        expect(Array.isArray(ss.rounds)).toBe(true);
-        expect(Array.isArray(ss.players)).toBe(true);
-      }
+      expect(family?.analyticsGroupingKey).toBe(
+        `local:${String(recipientFixture.scoresheetId)}`,
+      );
+      expect(family?.contributingVisibleScoresheets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            visibleScoresheetId: sharedFixture.sharedGameScoresheetId,
+            visibleScoresheetSourceType: "shared",
+            matchCount: 1,
+          }),
+        ]),
+      );
     });
 
-    test("scoresheet stats have correct shape", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
-      const { gameId } = await createGameWithFinishedMatch(caller, {
-        gameName: "SS Shape Game",
+    test("groups the same shared match differently for different recipients", async () => {
+      const ownerCaller = await createAuthenticatedCaller(
+        ownerLifecycle.userId,
+      );
+      const recipientACaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
+      const recipientBCaller = await createAuthenticatedCaller(
+        recipientBLifecycle.userId,
+      );
+
+      await ensureUserPlayer(recipientACaller);
+      await ensureUserPlayer(recipientBCaller);
+
+      const ownerFixture = await createGameWithAnalyticsScoresheet(
+        ownerCaller,
+        {
+          gameName: "Shared Divergence Game",
+        },
+      );
+      const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+        gameId: ownerFixture.gameId,
+        scoresheetId: ownerFixture.scoresheetId,
+        matchName: "Shared Divergence Match",
       });
 
-      const result = await caller.game.getGameScoresheetStats({
+      const recipientALocal = await createGameWithAnalyticsScoresheet(
+        recipientACaller,
+        {
+          gameName: "Recipient A Local Game",
+          scoresheetName: "Recipient A Sheet",
+        },
+      );
+
+      const sharedForA = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientALocal.gameId,
+      });
+      const sharedForB = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientBLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+      });
+
+      await recipientACaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedForA.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientALocal.scoresheetId,
+      });
+      await recipientACaller.game.linkSharedRoundsAnalytics({
+        sharedScoresheetId: sharedForA.sharedGameScoresheetId,
+        links: sharedForA.sharedGameRounds.map((sharedRound, index) => ({
+          sharedRoundId: sharedRound.id,
+          analyticsLinkedRoundId: recipientALocal.rounds[index]?.id ?? null,
+        })),
+      });
+
+      const [
+        headerA,
+        headerB,
+        playerStatsA,
+        playerStatsB,
+        scoresheetStatsA,
+        scoresheetStatsB,
+      ] = await Promise.all([
+        recipientACaller.game.getGameStatsHeader({
+          type: "shared",
+          sharedGameId: sharedForA.sharedGameId,
+        }),
+        recipientBCaller.game.getGameStatsHeader({
+          type: "shared",
+          sharedGameId: sharedForB.sharedGameId,
+        }),
+        recipientACaller.game.getGamePlayerStats({
+          type: "shared",
+          sharedGameId: sharedForA.sharedGameId,
+        }),
+        recipientBCaller.game.getGamePlayerStats({
+          type: "shared",
+          sharedGameId: sharedForB.sharedGameId,
+        }),
+        recipientACaller.game.getGameScoresheetStats({
+          type: "shared",
+          sharedGameId: sharedForA.sharedGameId,
+        }),
+        recipientBCaller.game.getGameScoresheetStats({
+          type: "shared",
+          sharedGameId: sharedForB.sharedGameId,
+        }),
+      ]);
+
+      expect(headerA.overallMatchesPlayed).toBe(1);
+      expect(headerB.overallMatchesPlayed).toBe(1);
+      expect(playerStatsA.players).toHaveLength(playerStatsB.players.length);
+      expect(scoresheetStatsA).toHaveLength(1);
+      expect(scoresheetStatsB).toHaveLength(1);
+
+      expect(scoresheetStatsA[0]).toMatchObject({
         type: "original",
-        id: gameId,
+        id: recipientALocal.scoresheetId,
+        analyticsGroupingScoresheetSourceType: "local",
+        linkageState: "shared_linked",
       });
-
-      const ss = result[0];
-      expect(ss).toBeDefined();
-      if (ss) {
-        expect(ss.type).toBe("original");
-        if (ss.type === "original") {
-          expect(ss.id).toBeDefined();
-          expect(ss.isDefault).toBeDefined();
-        }
-        expect(ss.name).toBeDefined();
-        expect(typeof ss.plays).toBe("number");
-        expect(Array.isArray(ss.rounds)).toBe(true);
-        expect(Array.isArray(ss.players)).toBe(true);
-      }
+      expect(scoresheetStatsB[0]).toMatchObject({
+        type: "shared",
+        sharedId: sharedForB.sharedGameScoresheetId,
+        analyticsGroupingScoresheetSourceType: "shared",
+        linkageState: "shared_unlinked",
+      });
+      expect(scoresheetStatsA[0]?.analyticsGroupingKey).toBe(
+        `local:${String(recipientALocal.scoresheetId)}`,
+      );
+      expect(scoresheetStatsB[0]?.analyticsGroupingKey).toBe(
+        `shared:${String(sharedForB.sharedGameScoresheetId)}`,
+      );
     });
 
-    test("throws for non-existent game", async () => {
-      const caller = await createAuthenticatedCaller(lifecycle.userId);
+    test("preserves mixed linked and unlinked rounds within one shared scoresheet family", async () => {
+      const ownerCaller = await createAuthenticatedCaller(
+        ownerLifecycle.userId,
+      );
+      const recipientCaller = await createAuthenticatedCaller(
+        recipientLifecycle.userId,
+      );
 
-      await expect(
-        caller.game.getGameScoresheetStats({ type: "original", id: 999999 }),
-      ).rejects.toThrow();
+      const ownerFixture = await createGameWithAnalyticsScoresheet(
+        ownerCaller,
+        {
+          gameName: "Shared Partial Round Game",
+        },
+      );
+      const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+        gameId: ownerFixture.gameId,
+        scoresheetId: ownerFixture.scoresheetId,
+        matchName: "Shared Partial Round Match",
+      });
+      const recipientFixture = await createGameWithAnalyticsScoresheet(
+        recipientCaller,
+        {
+          gameName: "Recipient Partial Linked Game",
+          scoresheetName: "Recipient Partial Sheet",
+        },
+      );
+
+      const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+        ownerUserId: ownerLifecycle.userId,
+        recipientUserId: recipientLifecycle.userId,
+        gameId: ownerFixture.gameId,
+        gameScoresheetId: ownerFixture.scoresheetId,
+        matchId: ownerMatch.matchId,
+        matchScoresheetId: ownerMatch.matchScoresheetId,
+        linkedGameId: recipientFixture.gameId,
+      });
+
+      const firstSharedRound = sharedFixture.sharedGameRounds[0];
+      const secondSharedRound = sharedFixture.sharedGameRounds[1];
+      const firstLocalRound = recipientFixture.rounds[0];
+
+      expect(firstSharedRound).toBeDefined();
+      expect(secondSharedRound).toBeDefined();
+      expect(firstLocalRound).toBeDefined();
+
+      await recipientCaller.game.linkSharedScoresheetAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      });
+      await recipientCaller.game.linkSharedRoundsAnalytics({
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        links: [
+          {
+            sharedRoundId: firstSharedRound!.id,
+            analyticsLinkedRoundId: firstLocalRound!.id,
+          },
+        ],
+      });
+
+      const linkState =
+        await recipientCaller.game.getSharedScoresheetAnalyticsLinkState({
+          sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        });
+      const scoresheetStats = await recipientCaller.game.getGameScoresheetStats(
+        {
+          type: "shared",
+          sharedGameId: sharedFixture.sharedGameId,
+        },
+      );
+
+      expect(linkState.linkageState).toBe("shared_linked");
+      expect(linkState.rounds).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sharedRoundId: firstSharedRound!.id,
+            analyticsLinkedRoundId: firstLocalRound!.id,
+            linkageState: "shared_linked",
+          }),
+          expect.objectContaining({
+            sharedRoundId: secondSharedRound!.id,
+            analyticsLinkedRoundId: null,
+            linkageState: "shared_unlinked",
+          }),
+        ]),
+      );
+
+      const [family] = scoresheetStats;
+      expect(family).toBeDefined();
+
+      const roundByName = new Map(
+        family?.rounds.map((round) => [round.name, round]) ?? [],
+      );
+      expect(roundByName.get("Points")?.id).toBe(firstLocalRound!.id);
+      expect(roundByName.get("Bonus")?.id).toBe(secondSharedRound!.id);
     });
   });
 });

--- a/packages/api/src/routers/game/game.stats.test.ts
+++ b/packages/api/src/routers/game/game.stats.test.ts
@@ -57,8 +57,6 @@ describe("Game stats router analytics integration", () => {
         recipientLifecycle.userId,
       );
 
-      await ensureUserPlayer(recipientCaller);
-
       const ownerFixture = await createGameWithAnalyticsScoresheet(
         ownerCaller,
         {
@@ -131,9 +129,9 @@ describe("Game stats router analytics integration", () => {
       expect(
         playerStats.players.every((player) => player.type === "shared"),
       ).toBe(true);
-      expect(playerStats.players.map((player) => player.name).sort()).toEqual(
-        ownerMatch.players.map((player) => player.name).sort(),
-      );
+      expect(
+        playerStats.players.map((player) => player.name).toSorted(),
+      ).toEqual(ownerMatch.players.map((player) => player.name).toSorted());
     });
   });
 
@@ -165,9 +163,9 @@ describe("Game stats router analytics integration", () => {
       });
 
       expect(header.overallMatchesPlayed).toBe(1);
-      expect(playerStats.players.map((player) => player.name).sort()).toEqual(
-        finishedMatch.players.map((player) => player.name).sort(),
-      );
+      expect(
+        playerStats.players.map((player) => player.name).toSorted(),
+      ).toEqual(finishedMatch.players.map((player) => player.name).toSorted());
       expect(scoresheetStats).toHaveLength(1);
 
       const [family] = scoresheetStats;
@@ -438,7 +436,8 @@ describe("Game stats router analytics integration", () => {
 
       expect(headerA.overallMatchesPlayed).toBe(1);
       expect(headerB.overallMatchesPlayed).toBe(1);
-      expect(playerStatsA.players).toHaveLength(playerStatsB.players.length);
+      expect(playerStatsA.players).toHaveLength(2);
+      expect(playerStatsB.players).toHaveLength(2);
       expect(scoresheetStatsA).toHaveLength(1);
       expect(scoresheetStatsB).toHaveLength(1);
 

--- a/packages/api/src/routers/game/game.stats.test.ts
+++ b/packages/api/src/routers/game/game.stats.test.ts
@@ -550,6 +550,7 @@ describe("Game stats router analytics integration", () => {
 
       const [family] = scoresheetStats;
       expect(family).toBeDefined();
+      expect(family?.linkageState).toBe("shared_linked");
 
       const roundByName = new Map(
         family?.rounds.map((round) => [round.name, round]) ?? [],

--- a/packages/api/src/routers/match/match.create.shared-analytics.test.ts
+++ b/packages/api/src/routers/match/match.create.shared-analytics.test.ts
@@ -1,0 +1,340 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "vitest";
+
+import { eq } from "drizzle-orm";
+import { db } from "@board-games/db/client";
+import { sharedRound, sharedScoresheet } from "@board-games/db/schema";
+
+import {
+  createFinishedMatchForScoresheet,
+  createGameWithAnalyticsScoresheet,
+  getLocalOriginalScoresheetsForUser,
+  getMatchById,
+  getSharedScoresheetById,
+  shareFinishedMatchAnalyticsWithRecipient,
+} from "../game/game.analytics-test-fixtures";
+import {
+  createAuthenticatedCaller,
+  createPlayers,
+  matchTestLifecycle,
+} from "./match-test-fixtures";
+
+describe("Match creation from shared scoresheets seeds analytics linkage", () => {
+  const ownerLifecycle = matchTestLifecycle();
+  const recipientLifecycle = matchTestLifecycle();
+
+  beforeAll(async () => {
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+  });
+
+  afterAll(async () => {
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+  });
+
+  beforeEach(async () => {
+    await ownerLifecycle.createTestUser();
+    await recipientLifecycle.createTestUser();
+  });
+
+  afterEach(async () => {
+    await ownerLifecycle.deleteTestUser();
+    await recipientLifecycle.deleteTestUser();
+  });
+
+  const createRecipientSharedMatch = async (options: {
+    recipientUserId: string;
+    sharedGameId: number;
+    sharedScoresheetId: number;
+    matchName: string;
+  }) => {
+    const recipientCaller = await createAuthenticatedCaller(
+      options.recipientUserId,
+    );
+    const players = await createPlayers(
+      recipientCaller,
+      2,
+      `${options.matchName} Player`,
+    );
+
+    return recipientCaller.match.createMatch({
+      name: options.matchName,
+      date: new Date("2026-03-12T12:00:00.000Z"),
+      game: { type: "shared", sharedGameId: options.sharedGameId },
+      scoresheet: { type: "shared", sharedId: options.sharedScoresheetId },
+      players: players.map((player) => ({
+        type: "original" as const,
+        id: player.id,
+        roles: [],
+        teamId: null,
+      })),
+      teams: [],
+      location: null,
+    });
+  };
+
+  test("materializes a local original and analytics-links it on first shared create", async () => {
+    const ownerCaller = await createAuthenticatedCaller(ownerLifecycle.userId);
+
+    const ownerFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
+      gameName: "Shared Create Source Game",
+    });
+    const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+      gameId: ownerFixture.gameId,
+      scoresheetId: ownerFixture.scoresheetId,
+      matchName: "Shared Create Source Match",
+    });
+
+    const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+      ownerUserId: ownerLifecycle.userId,
+      recipientUserId: recipientLifecycle.userId,
+      gameId: ownerFixture.gameId,
+      gameScoresheetId: ownerFixture.scoresheetId,
+      matchId: ownerMatch.matchId,
+      matchScoresheetId: ownerMatch.matchScoresheetId,
+    });
+
+    const createdMatch = await createRecipientSharedMatch({
+      recipientUserId: recipientLifecycle.userId,
+      sharedGameId: sharedFixture.sharedGameId,
+      sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+      matchName: "Recipient First Shared Match",
+    });
+
+    const sharedGameRow = await db.query.sharedGame.findFirst({
+      where: {
+        id: sharedFixture.sharedGameId,
+      },
+    });
+    const linkedGameId = sharedGameRow?.linkedGameId ?? null;
+
+    expect(linkedGameId).not.toBeNull();
+
+    const localOriginals = await getLocalOriginalScoresheetsForUser({
+      userId: recipientLifecycle.userId,
+      gameId: linkedGameId!,
+    });
+    expect(localOriginals).toHaveLength(1);
+
+    const [localOriginal] = localOriginals;
+    expect(localOriginal).toMatchObject({
+      type: "Game",
+      forkedFromScoresheetId: ownerFixture.scoresheetId,
+      forkedFromSharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+    });
+
+    const sharedScoresheetRow = await getSharedScoresheetById(
+      sharedFixture.sharedGameScoresheetId,
+    );
+    expect(sharedScoresheetRow).toMatchObject({
+      id: sharedFixture.sharedGameScoresheetId,
+      analyticsLinkedScoresheetId: localOriginal?.id,
+      linkedScoresheetId: localOriginal?.id,
+    });
+
+    expect(sharedScoresheetRow?.sharedRounds).toHaveLength(
+      localOriginal?.rounds.length ?? 0,
+    );
+    sharedScoresheetRow?.sharedRounds.forEach((sharedRoundRow, index) => {
+      expect(sharedRoundRow.analyticsLinkedRoundId).toBe(
+        localOriginal?.rounds[index]?.id,
+      );
+      expect(sharedRoundRow.linkedRoundId).toBe(
+        localOriginal?.rounds[index]?.id,
+      );
+    });
+
+    const createdMatchRow = await getMatchById(createdMatch.id);
+    expect(createdMatchRow).toBeDefined();
+
+    const matchScoresheetRow = await db.query.scoresheet.findFirst({
+      where: {
+        id: createdMatchRow!.scoresheetId,
+      },
+    });
+
+    expect(matchScoresheetRow).toMatchObject({
+      type: "Match",
+      parentId: localOriginal?.id,
+      forkedFromScoresheetId: localOriginal?.id,
+    });
+  });
+
+  test("reuses the same materialized local original on the second shared create", async () => {
+    const ownerCaller = await createAuthenticatedCaller(ownerLifecycle.userId);
+
+    const ownerFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
+      gameName: "Shared Reuse Source Game",
+    });
+    const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+      gameId: ownerFixture.gameId,
+      scoresheetId: ownerFixture.scoresheetId,
+      matchName: "Shared Reuse Source Match",
+    });
+
+    const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+      ownerUserId: ownerLifecycle.userId,
+      recipientUserId: recipientLifecycle.userId,
+      gameId: ownerFixture.gameId,
+      gameScoresheetId: ownerFixture.scoresheetId,
+      matchId: ownerMatch.matchId,
+      matchScoresheetId: ownerMatch.matchScoresheetId,
+    });
+
+    const firstMatch = await createRecipientSharedMatch({
+      recipientUserId: recipientLifecycle.userId,
+      sharedGameId: sharedFixture.sharedGameId,
+      sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+      matchName: "Recipient Reuse Shared Match One",
+    });
+    const secondMatch = await createRecipientSharedMatch({
+      recipientUserId: recipientLifecycle.userId,
+      sharedGameId: sharedFixture.sharedGameId,
+      sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+      matchName: "Recipient Reuse Shared Match Two",
+    });
+
+    const sharedGameRow = await db.query.sharedGame.findFirst({
+      where: {
+        id: sharedFixture.sharedGameId,
+      },
+    });
+
+    const localOriginals = await getLocalOriginalScoresheetsForUser({
+      userId: recipientLifecycle.userId,
+      gameId: sharedGameRow!.linkedGameId!,
+    });
+
+    expect(localOriginals).toHaveLength(1);
+
+    const [localOriginal] = localOriginals;
+    const firstMatchRow = await getMatchById(firstMatch.id);
+    const secondMatchRow = await getMatchById(secondMatch.id);
+
+    const firstMatchScoresheet = await db.query.scoresheet.findFirst({
+      where: {
+        id: firstMatchRow!.scoresheetId,
+      },
+    });
+    const secondMatchScoresheet = await db.query.scoresheet.findFirst({
+      where: {
+        id: secondMatchRow!.scoresheetId,
+      },
+    });
+
+    expect(firstMatchScoresheet?.parentId).toBe(localOriginal?.id);
+    expect(secondMatchScoresheet?.parentId).toBe(localOriginal?.id);
+
+    const sharedScoresheetRow = await getSharedScoresheetById(
+      sharedFixture.sharedGameScoresheetId,
+    );
+    expect(sharedScoresheetRow?.analyticsLinkedScoresheetId).toBe(
+      localOriginal?.id,
+    );
+  });
+
+  test("promotes a legacy materialized copy into analytics linkage without duplicating it", async () => {
+    const ownerCaller = await createAuthenticatedCaller(ownerLifecycle.userId);
+    const recipientCaller = await createAuthenticatedCaller(
+      recipientLifecycle.userId,
+    );
+
+    const ownerFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
+      gameName: "Legacy Promotion Source Game",
+    });
+    const ownerMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+      gameId: ownerFixture.gameId,
+      scoresheetId: ownerFixture.scoresheetId,
+      matchName: "Legacy Promotion Source Match",
+    });
+    const recipientFixture = await createGameWithAnalyticsScoresheet(
+      recipientCaller,
+      {
+        gameName: "Recipient Legacy Local Game",
+        scoresheetName: "Recipient Legacy Local Sheet",
+      },
+    );
+
+    const sharedFixture = await shareFinishedMatchAnalyticsWithRecipient({
+      ownerUserId: ownerLifecycle.userId,
+      recipientUserId: recipientLifecycle.userId,
+      gameId: ownerFixture.gameId,
+      gameScoresheetId: ownerFixture.scoresheetId,
+      matchId: ownerMatch.matchId,
+      matchScoresheetId: ownerMatch.matchScoresheetId,
+      linkedGameId: recipientFixture.gameId,
+    });
+
+    await db
+      .update(sharedScoresheet)
+      .set({
+        linkedScoresheetId: recipientFixture.scoresheetId,
+        analyticsLinkedScoresheetId: null,
+      })
+      .where(eq(sharedScoresheet.id, sharedFixture.sharedGameScoresheetId));
+
+    for (const [
+      index,
+      sharedRoundRow,
+    ] of sharedFixture.sharedGameRounds.entries()) {
+      await db
+        .update(sharedRound)
+        .set({
+          linkedRoundId: recipientFixture.rounds[index]!.id,
+          analyticsLinkedRoundId: null,
+        })
+        .where(eq(sharedRound.id, sharedRoundRow.id));
+    }
+
+    const createdMatch = await createRecipientSharedMatch({
+      recipientUserId: recipientLifecycle.userId,
+      sharedGameId: sharedFixture.sharedGameId,
+      sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+      matchName: "Recipient Legacy Promotion Match",
+    });
+
+    const localOriginals = await getLocalOriginalScoresheetsForUser({
+      userId: recipientLifecycle.userId,
+      gameId: recipientFixture.gameId,
+    });
+
+    expect(localOriginals).toHaveLength(1);
+    expect(localOriginals[0]).toMatchObject({
+      id: recipientFixture.scoresheetId,
+      forkedFromSharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+    });
+
+    const sharedScoresheetRow = await getSharedScoresheetById(
+      sharedFixture.sharedGameScoresheetId,
+    );
+    expect(sharedScoresheetRow).toMatchObject({
+      analyticsLinkedScoresheetId: recipientFixture.scoresheetId,
+      linkedScoresheetId: recipientFixture.scoresheetId,
+    });
+    sharedScoresheetRow?.sharedRounds.forEach((sharedRoundRow, index) => {
+      expect(sharedRoundRow.analyticsLinkedRoundId).toBe(
+        recipientFixture.rounds[index]?.id,
+      );
+      expect(sharedRoundRow.linkedRoundId).toBe(
+        recipientFixture.rounds[index]?.id,
+      );
+    });
+
+    const createdMatchRow = await getMatchById(createdMatch.id);
+    const matchScoresheetRow = await db.query.scoresheet.findFirst({
+      where: {
+        id: createdMatchRow!.scoresheetId,
+      },
+    });
+
+    expect(matchScoresheetRow?.parentId).toBe(recipientFixture.scoresheetId);
+  });
+});

--- a/packages/api/src/routers/match/match.create.shared-analytics.test.ts
+++ b/packages/api/src/routers/match/match.create.shared-analytics.test.ts
@@ -168,7 +168,7 @@ describe("Match creation from shared scoresheets seeds analytics linkage", () =>
     });
   });
 
-  test("reuses the same materialized local original on the second shared create", async () => {
+  test("reuses the same materialized local original across concurrent shared creates", async () => {
     const ownerCaller = await createAuthenticatedCaller(ownerLifecycle.userId);
 
     const ownerFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
@@ -189,18 +189,20 @@ describe("Match creation from shared scoresheets seeds analytics linkage", () =>
       matchScoresheetId: ownerMatch.matchScoresheetId,
     });
 
-    const firstMatch = await createRecipientSharedMatch({
-      recipientUserId: recipientLifecycle.userId,
-      sharedGameId: sharedFixture.sharedGameId,
-      sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
-      matchName: "Recipient Reuse Shared Match One",
-    });
-    const secondMatch = await createRecipientSharedMatch({
-      recipientUserId: recipientLifecycle.userId,
-      sharedGameId: sharedFixture.sharedGameId,
-      sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
-      matchName: "Recipient Reuse Shared Match Two",
-    });
+    const [firstMatch, secondMatch] = await Promise.all([
+      createRecipientSharedMatch({
+        recipientUserId: recipientLifecycle.userId,
+        sharedGameId: sharedFixture.sharedGameId,
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        matchName: "Recipient Reuse Shared Match One",
+      }),
+      createRecipientSharedMatch({
+        recipientUserId: recipientLifecycle.userId,
+        sharedGameId: sharedFixture.sharedGameId,
+        sharedScoresheetId: sharedFixture.sharedGameScoresheetId,
+        matchName: "Recipient Reuse Shared Match Two",
+      }),
+    ]);
 
     const sharedGameRow = await db.query.sharedGame.findFirst({
       where: {
@@ -239,6 +241,73 @@ describe("Match creation from shared scoresheets seeds analytics linkage", () =>
     expect(sharedScoresheetRow?.analyticsLinkedScoresheetId).toBe(
       localOriginal?.id,
     );
+  });
+
+  test("rejects a shared scoresheet that does not belong to the selected shared game", async () => {
+    const ownerCaller = await createAuthenticatedCaller(ownerLifecycle.userId);
+    const recipientCaller = await createAuthenticatedCaller(
+      recipientLifecycle.userId,
+    );
+
+    const firstFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
+      gameName: "Scoped Shared Game One",
+    });
+    const firstMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+      gameId: firstFixture.gameId,
+      scoresheetId: firstFixture.scoresheetId,
+      matchName: "Scoped Shared Match One",
+    });
+    const secondFixture = await createGameWithAnalyticsScoresheet(ownerCaller, {
+      gameName: "Scoped Shared Game Two",
+    });
+    const secondMatch = await createFinishedMatchForScoresheet(ownerCaller, {
+      gameId: secondFixture.gameId,
+      scoresheetId: secondFixture.scoresheetId,
+      matchName: "Scoped Shared Match Two",
+    });
+
+    const sharedFixtureOne = await shareFinishedMatchAnalyticsWithRecipient({
+      ownerUserId: ownerLifecycle.userId,
+      recipientUserId: recipientLifecycle.userId,
+      gameId: firstFixture.gameId,
+      gameScoresheetId: firstFixture.scoresheetId,
+      matchId: firstMatch.matchId,
+      matchScoresheetId: firstMatch.matchScoresheetId,
+    });
+    const sharedFixtureTwo = await shareFinishedMatchAnalyticsWithRecipient({
+      ownerUserId: ownerLifecycle.userId,
+      recipientUserId: recipientLifecycle.userId,
+      gameId: secondFixture.gameId,
+      gameScoresheetId: secondFixture.scoresheetId,
+      matchId: secondMatch.matchId,
+      matchScoresheetId: secondMatch.matchScoresheetId,
+    });
+
+    const createdPlayers = await createPlayers(
+      recipientCaller,
+      2,
+      "Scoped Shared Player",
+    );
+
+    await expect(
+      recipientCaller.match.createMatch({
+        name: "Scoped Shared Mismatch",
+        date: new Date("2026-03-14T12:00:00.000Z"),
+        game: { type: "shared", sharedGameId: sharedFixtureOne.sharedGameId },
+        scoresheet: {
+          type: "shared",
+          sharedId: sharedFixtureTwo.sharedGameScoresheetId,
+        },
+        players: createdPlayers.map((player) => ({
+          type: "original" as const,
+          id: player.id,
+          roles: [],
+          teamId: null,
+        })),
+        teams: [],
+        location: null,
+      }),
+    ).rejects.toThrow("Shared scoresheet not found. For Create Match");
   });
 
   test("promotes a legacy materialized copy into analytics linkage without duplicating it", async () => {

--- a/packages/api/src/routers/match/sub-routers/date/repository/date-match.repository.ts
+++ b/packages/api/src/routers/match/sub-routers/date/repository/date-match.repository.ts
@@ -246,6 +246,7 @@ class DateMatchRepository {
           forkedFromTemplateVersion: number | null;
           templateRevisionOfScoresheetId: number | null;
           forkedFromScoresheetId: number | null;
+          forkedFromSharedScoresheetId: number | null;
           forkedFromGameId: number | null;
           forkedForMatchId: number | null;
           name: string;
@@ -267,6 +268,7 @@ class DateMatchRepository {
                     'forkedFromTemplateVersion', ${scoresheet.forkedFromTemplateVersion},
                     'templateRevisionOfScoresheetId', ${scoresheet.templateRevisionOfScoresheetId},
                     'forkedFromScoresheetId', ${scoresheet.forkedFromScoresheetId},
+                    'forkedFromSharedScoresheetId', ${scoresheet.forkedFromSharedScoresheetId},
                     'forkedFromGameId', ${scoresheet.forkedFromGameId},
                     'forkedForMatchId', ${scoresheet.forkedForMatchId},
                     'name', ${scoresheet.name},

--- a/packages/api/src/services/game/game-analytics-link.service.ts
+++ b/packages/api/src/services/game/game-analytics-link.service.ts
@@ -106,10 +106,26 @@ class GameAnalyticsLinkService {
         }
       }
 
+      const previousLinkedScoresheetId =
+        sharedScoresheet.analyticsLinkedScoresheetId;
+      if (
+        previousLinkedScoresheetId !== null &&
+        previousLinkedScoresheetId !== input.analyticsLinkedScoresheetId
+      ) {
+        await roundRepository.clearSharedRoundsAnalyticsLinksForScoresheet({
+          input: {
+            sharedScoresheetId: input.sharedScoresheetId,
+            linkedScoresheetId: previousLinkedScoresheetId,
+          },
+          tx,
+        });
+      }
+
       await scoresheetRepository.linkSharedScoresheetAnalytics({
         input: {
           sharedScoresheetId: input.sharedScoresheetId,
           linkedScoresheetId: input.analyticsLinkedScoresheetId,
+          sharedWithId: ctx.userId,
         },
         tx,
       });
@@ -198,6 +214,8 @@ class GameAnalyticsLinkService {
 
       await roundRepository.bulkLinkSharedRoundsAnalytics({
         input: {
+          sharedScoresheetId: input.sharedScoresheetId,
+          linkedScoresheetId,
           links: input.links.map((link) => ({
             sharedRoundId: link.sharedRoundId,
             linkedRoundId: link.analyticsLinkedRoundId,

--- a/packages/api/src/services/game/game-analytics-link.service.ts
+++ b/packages/api/src/services/game/game-analytics-link.service.ts
@@ -1,0 +1,212 @@
+import { TRPCError } from "@trpc/server";
+
+import { db } from "@board-games/db/client";
+
+import type { GetSharedScoresheetAnalyticsLinkStateOutputType } from "../../routers/game/game.output";
+import type {
+  GetSharedScoresheetAnalyticsLinkStateArgs,
+  LinkSharedRoundsAnalyticsArgs,
+  LinkSharedScoresheetAnalyticsArgs,
+} from "./game.service.types";
+import { roundRepository } from "../../repositories/scoresheet/round.repository";
+import { scoresheetRepository } from "../../repositories/scoresheet/scoresheet.repository";
+
+class GameAnalyticsLinkService {
+  public async getSharedScoresheetAnalyticsLinkState(
+    args: GetSharedScoresheetAnalyticsLinkStateArgs,
+  ): Promise<GetSharedScoresheetAnalyticsLinkStateOutputType> {
+    const sharedScoresheet =
+      await scoresheetRepository.getSharedScoresheetAnalyticsState({
+        input: {
+          sharedScoresheetId: args.input.sharedScoresheetId,
+          userId: args.ctx.userId,
+        },
+      });
+
+    if (!sharedScoresheet) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Shared scoresheet not found.",
+      });
+    }
+
+    return {
+      sharedScoresheetId: sharedScoresheet.id,
+      analyticsLinkedScoresheetId:
+        sharedScoresheet.analyticsLinkedScoresheetId ?? null,
+      legacyLinkedScoresheetId: sharedScoresheet.linkedScoresheetId ?? null,
+      linkageState:
+        sharedScoresheet.analyticsLinkedScoresheetId === null
+          ? "shared_unlinked"
+          : "shared_linked",
+      rounds: sharedScoresheet.sharedRounds.map((sharedRound) => ({
+        sharedRoundId: sharedRound.id,
+        roundId: sharedRound.roundId,
+        roundName: sharedRound.round.name,
+        analyticsLinkedRoundId: sharedRound.analyticsLinkedRoundId ?? null,
+        legacyLinkedRoundId: sharedRound.linkedRoundId ?? null,
+        linkageState:
+          sharedRound.analyticsLinkedRoundId === null
+            ? "shared_unlinked"
+            : "shared_linked",
+      })),
+    };
+  }
+
+  public async linkSharedScoresheetAnalytics(
+    args: LinkSharedScoresheetAnalyticsArgs,
+  ) {
+    const { input, ctx } = args;
+
+    await db.transaction(async (tx) => {
+      const sharedScoresheet =
+        await scoresheetRepository.getSharedScoresheetAnalyticsState({
+          input: {
+            sharedScoresheetId: input.sharedScoresheetId,
+            userId: ctx.userId,
+          },
+          tx,
+        });
+
+      if (!sharedScoresheet) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Shared scoresheet not found.",
+        });
+      }
+
+      if (input.analyticsLinkedScoresheetId !== null) {
+        const linkedScoresheet = await scoresheetRepository.get(
+          {
+            id: input.analyticsLinkedScoresheetId,
+            createdBy: ctx.userId,
+            with: {
+              game: true,
+            },
+          },
+          tx,
+        );
+
+        if (!linkedScoresheet) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Linked scoresheet not found.",
+          });
+        }
+
+        if (
+          sharedScoresheet.sharedGame.linkedGameId !== null &&
+          linkedScoresheet.gameId !== sharedScoresheet.sharedGame.linkedGameId
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Linked scoresheet must belong to the local game linked from this shared game.",
+          });
+        }
+      }
+
+      await scoresheetRepository.linkSharedScoresheetAnalytics({
+        input: {
+          sharedScoresheetId: input.sharedScoresheetId,
+          linkedScoresheetId: input.analyticsLinkedScoresheetId,
+        },
+        tx,
+      });
+    });
+  }
+
+  public async linkSharedRoundsAnalytics(args: LinkSharedRoundsAnalyticsArgs) {
+    const { input, ctx } = args;
+
+    await db.transaction(async (tx) => {
+      const sharedScoresheet =
+        await scoresheetRepository.getSharedScoresheetAnalyticsState({
+          input: {
+            sharedScoresheetId: input.sharedScoresheetId,
+            userId: ctx.userId,
+          },
+          tx,
+        });
+
+      if (!sharedScoresheet) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Shared scoresheet not found.",
+        });
+      }
+
+      const linkedScoresheetId = sharedScoresheet.analyticsLinkedScoresheetId;
+      if (linkedScoresheetId === null) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Shared scoresheet must be linked to a local scoresheet before linking rounds.",
+        });
+      }
+
+      const linkedScoresheet = await scoresheetRepository.get(
+        {
+          id: linkedScoresheetId,
+          createdBy: ctx.userId,
+          with: {
+            rounds: {
+              where: {
+                deletedAt: {
+                  isNull: true,
+                },
+              },
+            },
+          },
+        },
+        tx,
+      );
+
+      if (!linkedScoresheet) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Linked scoresheet not found.",
+        });
+      }
+
+      const sharedRoundIds = new Set(
+        sharedScoresheet.sharedRounds.map((sharedRound) => sharedRound.id),
+      );
+      const localRoundIds = new Set(
+        linkedScoresheet.rounds.map((round) => round.id),
+      );
+
+      for (const link of input.links) {
+        if (!sharedRoundIds.has(link.sharedRoundId)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Shared round ${String(link.sharedRoundId)} does not belong to this shared scoresheet.`,
+          });
+        }
+
+        if (
+          link.analyticsLinkedRoundId !== null &&
+          !localRoundIds.has(link.analyticsLinkedRoundId)
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Analytics-linked round must belong to the analytics-linked local scoresheet.",
+          });
+        }
+      }
+
+      await roundRepository.bulkLinkSharedRoundsAnalytics({
+        input: {
+          links: input.links.map((link) => ({
+            sharedRoundId: link.sharedRoundId,
+            linkedRoundId: link.analyticsLinkedRoundId,
+          })),
+        },
+        tx,
+      });
+    });
+  }
+}
+
+export const gameAnalyticsLinkService = new GameAnalyticsLinkService();

--- a/packages/api/src/services/game/game-stats.service.ts
+++ b/packages/api/src/services/game/game-stats.service.ts
@@ -41,17 +41,6 @@ class GameStatsService {
     const userPlayerId = await playerRepository.getUserPlayerIdForUser({
       userId: ctx.userId,
     });
-    if (userPlayerId === null) {
-      return {
-        winRate: 0,
-        avgPlaytime: 0,
-        totalPlaytime: 0,
-        userTotalPlaytime: 0,
-        userAvgPlaytime: 0,
-        overallMatchesPlayed: 0,
-        userMatchesPlayed: 0,
-      };
-    }
 
     const stats = await gameStatsRepository.getGameStatsHeaderData({
       input,
@@ -59,19 +48,23 @@ class GameStatsService {
       userPlayerId,
     });
 
+    const userMatchesPlayed =
+      userPlayerId === null ? 0 : Number(stats.userMatchesPlayed);
     const winRate =
-      stats.userMatchesPlayed > 0
-        ? (stats.userWins / stats.userMatchesPlayed) * 100
-        : 0;
+      userMatchesPlayed > 0 ? (stats.userWins / userMatchesPlayed) * 100 : 0;
 
     return {
       winRate: Number(Number(winRate).toFixed(2)),
       avgPlaytime: Number(Number(stats.avgPlaytime).toFixed(0)),
       totalPlaytime: Number(stats.totalPlaytime),
-      userTotalPlaytime: Number(stats.userTotalPlaytime),
-      userAvgPlaytime: Number(Number(stats.userAvgPlaytime).toFixed(0)),
+      userTotalPlaytime:
+        userPlayerId === null ? 0 : Number(stats.userTotalPlaytime),
+      userAvgPlaytime:
+        userPlayerId === null
+          ? 0
+          : Number(Number(stats.userAvgPlaytime).toFixed(0)),
       overallMatchesPlayed: Number(stats.overallMatchesPlayed),
-      userMatchesPlayed: Number(stats.userMatchesPlayed),
+      userMatchesPlayed,
     };
   }
 

--- a/packages/api/src/services/game/game-stats.service.ts
+++ b/packages/api/src/services/game/game-stats.service.ts
@@ -1,6 +1,5 @@
 import { TRPCError } from "@trpc/server";
 
-import type { TransactionType } from "@board-games/db/client";
 import { db } from "@board-games/db/client";
 
 import type { GetGameStatsHeaderOutputType } from "../../repositories/game/game.repository.types";
@@ -14,14 +13,12 @@ import type {
 import type {
   AggregatedRound,
   AggregatedRoundPlayer,
-  AggregatedScoresheet,
+  AggregatedScoresheetFamily,
   AggregatedScoresheetMap,
   GamePlayerStatsAccEntry,
   GamePlayerStatsPlayerImage,
-  GetGameScoresheetStatsScoreSheetType,
   MatchResult,
   MatchResultByPlayerEntry,
-  MatchRoundEntry,
 } from "./game-stats.service.types";
 import type {
   GetGamePlayerStatsArgs,
@@ -30,167 +27,56 @@ import type {
 } from "./game.service.types";
 import { gameStatsRepository } from "../../repositories/game/game-stats.repository";
 import { gameRepository } from "../../repositories/game/game.repository";
-import { scoresheetRepository } from "../../repositories/scoresheet/scoresheet.repository";
 import { mapPlayerImageRowWithLogging } from "../../utils/image";
 
-/** One shared round from getAllSharedScoresheetsWithRounds (round + optional linked id). */
-type SharedRoundWithRound = Awaited<
-  ReturnType<typeof scoresheetRepository.getAllSharedScoresheetsWithRounds>
->[number]["sharedRounds"][number];
-
-/** One shared scoresheet from getAllSharedScoresheetsWithRounds. */
-type SharedScoresheetWithRounds = Awaited<
-  ReturnType<typeof scoresheetRepository.getAllSharedScoresheetsWithRounds>
->[number];
-
-/** One scoresheet from getAllScoresheetsWithRounds. */
-type OriginalScoresheetWithRounds = Awaited<
-  ReturnType<typeof scoresheetRepository.getAllScoresheetsWithRounds>
->[number];
-
-function buildOriginalScoresheetEntry(
-  originalScoresheet: OriginalScoresheetWithRounds,
-): Extract<GetGameScoresheetStatsScoreSheetType[number], { type: "original" }> {
-  return {
-    type: "original",
-    scoresheetId: originalScoresheet.id,
-    canonicalScoresheetId: originalScoresheet.parentId ?? originalScoresheet.id,
-    name: originalScoresheet.name,
-    isDefault: originalScoresheet.type === "Default",
-    targetScore: originalScoresheet.targetScore,
-    roundsScore: originalScoresheet.roundsScore,
-    winCondition: originalScoresheet.winCondition,
-    isCoop: originalScoresheet.isCoop,
-    rounds: originalScoresheet.rounds.map((round) => ({
-      id: round.id,
-      name: round.name,
-      type: round.type,
-      order: round.order,
-      score: round.score,
-      color: round.color,
-      lookup: round.lookup,
-      modifier: round.modifier,
-    })),
-  };
-}
-
-function mapSharedRounds(
-  sharedRounds: SharedRoundWithRound[],
-): GetGameScoresheetStatsScoreSheetType[number]["rounds"] {
-  return sharedRounds.map((sharedRound) => {
-    const round = sharedRound.round;
-    const id = sharedRound.linkedRoundId ?? round.id;
-    return {
-      id,
-      name: round.name,
-      type: round.type,
-      order: round.order,
-      score: round.score,
-      color: round.color,
-      lookup: round.lookup,
-      modifier: round.modifier,
-    };
-  });
-}
-
-function buildSharedScoresheetEntry(
-  sharedScoresheet: SharedScoresheetWithRounds,
-  rounds: GetGameScoresheetStatsScoreSheetType[number]["rounds"],
-): GetGameScoresheetStatsScoreSheetType[number] {
-  const s = sharedScoresheet.scoresheet;
-  return {
-    type: "shared",
-    scoresheetId: s.id,
-    canonicalScoresheetId: s.parentId ?? s.id,
-    sharedId: sharedScoresheet.id,
-    name: s.name,
-    isDefault: sharedScoresheet.isDefault,
-    permission: sharedScoresheet.permission,
-    isCoop: s.isCoop,
-    targetScore: s.targetScore,
-    roundsScore: s.roundsScore,
-    winCondition: s.winCondition,
-    rounds,
-  };
-}
-
-async function collectScoresheetsForOriginalGame(
-  userId: string,
-  gameId: number,
-  tx: TransactionType,
-): Promise<GetGameScoresheetStatsScoreSheetType> {
-  const returnedGame = await gameRepository.getGameWithLinkedGames(
-    { id: gameId, createdBy: userId },
-    tx,
-  );
-  if (!returnedGame) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Game not found.",
-    });
-  }
-  const originalScoresheets =
-    await scoresheetRepository.getAllScoresheetsWithRounds(
-      { createdBy: userId, gameId: returnedGame.id },
-      tx,
-    );
-  const sharedScoresheets =
-    await scoresheetRepository.getAllSharedScoresheetsWithRounds(
-      {
-        sharedWithId: userId,
-        sharedGameIds: returnedGame.linkedGames.map((lg) => lg.id),
-      },
-      tx,
-    );
-  const scoresheets: GetGameScoresheetStatsScoreSheetType = [];
-  for (const s of originalScoresheets) {
-    scoresheets.push(buildOriginalScoresheetEntry(s));
-  }
-  for (const s of sharedScoresheets) {
-    scoresheets.push(
-      buildSharedScoresheetEntry(s, mapSharedRounds(s.sharedRounds)),
-    );
-  }
-  return scoresheets;
-}
-
-async function collectScoresheetsForSharedGame(
-  userId: string,
-  sharedGameId: number,
-  tx: TransactionType,
-): Promise<GetGameScoresheetStatsScoreSheetType> {
-  const returnedSharedGame = await gameRepository.getSharedGame(
-    { id: sharedGameId, sharedWithId: userId },
-    tx,
-  );
-  if (!returnedSharedGame) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Shared game not found.",
-    });
-  }
-  const sharedScoresheets =
-    await scoresheetRepository.getAllSharedScoresheetsWithRounds(
-      { sharedWithId: userId, sharedGameIds: [returnedSharedGame.id] },
-      tx,
-    );
-  const scoresheets: GetGameScoresheetStatsScoreSheetType = [];
-  for (const s of sharedScoresheets) {
-    scoresheets.push(
-      buildSharedScoresheetEntry(s, mapSharedRounds(s.sharedRounds)),
-    );
-  }
-  return scoresheets;
-}
+const sharedPlayerTypes = new Set(["shared", "linked"]);
 
 class GameStatsService {
   public async getGameStatsHeader(
     args: GetGameStatsHeaderArgs,
   ): Promise<GetGameStatsHeaderOutputType> {
-    return gameStatsRepository.getGameStatsHeader({
-      input: args.input,
-      userId: args.ctx.userId,
+    const { input, ctx } = args;
+
+    await this.assertGameAccessible(input, ctx.userId);
+
+    const userPlayer = await db.query.player.findFirst({
+      where: {
+        isUser: true,
+        createdBy: ctx.userId,
+      },
     });
+    if (!userPlayer) {
+      return {
+        winRate: 0,
+        avgPlaytime: 0,
+        totalPlaytime: 0,
+        userTotalPlaytime: 0,
+        userAvgPlaytime: 0,
+        overallMatchesPlayed: 0,
+        userMatchesPlayed: 0,
+      };
+    }
+
+    const stats = await gameStatsRepository.getGameStatsHeaderData({
+      input,
+      userId: ctx.userId,
+      userPlayerId: userPlayer.id,
+    });
+
+    const winRate =
+      stats.userMatchesPlayed > 0
+        ? (stats.userWins / stats.userMatchesPlayed) * 100
+        : 0;
+
+    return {
+      winRate: Number(Number(winRate).toFixed(2)),
+      avgPlaytime: Number(Number(stats.avgPlaytime).toFixed(0)),
+      totalPlaytime: Number(stats.totalPlaytime),
+      userTotalPlaytime: Number(stats.userTotalPlaytime),
+      userAvgPlaytime: Number(Number(stats.userAvgPlaytime).toFixed(0)),
+      overallMatchesPlayed: Number(stats.overallMatchesPlayed),
+      userMatchesPlayed: Number(stats.userMatchesPlayed),
+    };
   }
 
   public async getGamePlayerStats(
@@ -198,30 +84,7 @@ class GameStatsService {
   ): Promise<GetGamePlayerStatsOutputType> {
     const { input, ctx } = args;
 
-    // Validate game existence to be consistent with getGameScoresheetStats
-    if (input.type === "original") {
-      const returnedGame = await gameRepository.getGameWithLinkedGames({
-        id: input.id,
-        createdBy: ctx.userId,
-      });
-      if (!returnedGame) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Game not found.",
-        });
-      }
-    } else {
-      const returnedSharedGame = await gameRepository.getSharedGame({
-        id: input.sharedGameId,
-        sharedWithId: ctx.userId,
-      });
-      if (!returnedSharedGame) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Shared game not found.",
-        });
-      }
-    }
+    await this.assertGameAccessible(input, ctx.userId);
 
     const matchPlayers = await gameStatsRepository.getGamePlayerStatsData({
       input,
@@ -256,7 +119,7 @@ class GameStatsService {
           mp.image === null || playerImage === null
             ? null
             : { id: mp.image.id, ...playerImage };
-        if (mp.type === "shared") {
+        if (sharedPlayerTypes.has(mp.type)) {
           if (mp.sharedId === null) {
             continue;
           }
@@ -318,27 +181,48 @@ class GameStatsService {
   ): Promise<GetGameScoresheetStatsOutputType> {
     const { input, ctx } = args;
 
-    const response = await db.transaction(async (tx) => {
-      const scoresheets =
-        input.type === "original"
-          ? await collectScoresheetsForOriginalGame(ctx.userId, input.id, tx)
-          : await collectScoresheetsForSharedGame(
-              ctx.userId,
-              input.sharedGameId,
-              tx,
-            );
-      const rawData = await gameStatsRepository.getGameScoresheetStatsData({
-        input,
-        userId: ctx.userId,
-        tx,
-      });
-      return { scoresheets, rawData };
+    await this.assertGameAccessible(input, ctx.userId);
+
+    const rawData = await gameStatsRepository.getGameScoresheetStatsData({
+      input,
+      userId: ctx.userId,
     });
 
-    if (response.rawData.length === 0) return [];
+    if (rawData.length === 0) return [];
 
-    const scoresheetMap = this.aggregateScoresheetData(response.rawData);
-    return this.calculateScoresheetStats(scoresheetMap, response.scoresheets);
+    const scoresheetMap = this.aggregateScoresheetData(rawData);
+    return this.calculateScoresheetStats(scoresheetMap);
+  }
+
+  private async assertGameAccessible(
+    input: GetGameStatsHeaderArgs["input"],
+    userId: string,
+  ) {
+    if (input.type === "original") {
+      const returnedGame = await gameRepository.getGameWithLinkedGames({
+        id: input.id,
+        createdBy: userId,
+      });
+      if (!returnedGame) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Game not found.",
+        });
+      }
+      return returnedGame;
+    }
+
+    const returnedSharedGame = await gameRepository.getSharedGame({
+      id: input.sharedGameId,
+      sharedWithId: userId,
+    });
+    if (!returnedSharedGame) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Shared game not found.",
+      });
+    }
+    return returnedSharedGame;
   }
 
   private calculateStdDev(scores: number[]): number | null {
@@ -355,59 +239,74 @@ class GameStatsService {
       ReturnType<typeof gameStatsRepository.getGameScoresheetStatsData>
     >,
   ): AggregatedScoresheetMap {
-    const scoresheetMap = new Map<number, AggregatedScoresheet>();
+    const scoresheetMap = new Map<string, AggregatedScoresheetFamily>();
 
     for (const row of rawData) {
-      if (!row.scoresheetParentId || !row.roundParentId) continue;
-
-      let scoresheet = scoresheetMap.get(row.scoresheetParentId);
+      let scoresheet = scoresheetMap.get(row.analyticsGroupingKey);
       if (!scoresheet) {
-        if (!row.scoresheetParentName) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Scoresheet parent name is required",
-          });
-        }
         scoresheet = {
-          id: row.scoresheetParentId,
-          name: row.scoresheetParentName,
-          rounds: new Map<number, AggregatedRound>(),
-          scoresheetRoundsScore: row.scoresheetRoundsScore,
-          scoresheetWinCondition: row.scoresheetWinCondition,
+          analyticsGroupingScoresheetId: row.analyticsGroupingScoresheetId,
+          analyticsGroupingScoresheetSourceType:
+            row.analyticsGroupingScoresheetSourceType,
+          analyticsGroupingKey: row.analyticsGroupingKey,
+          linkageState: row.linkageState,
+          name: row.analyticsScoresheetName,
+          isCoop: row.analyticsScoresheetIsCoop,
+          targetScore: row.analyticsScoresheetTargetScore,
+          roundsScore: row.analyticsScoresheetRoundsScore,
+          winCondition: row.analyticsScoresheetWinCondition,
+          isDefault: row.analyticsScoresheetIsDefault,
+          permission: row.analyticsScoresheetPermission ?? null,
+          rounds: new Map<string, AggregatedRound>(),
           matchResultsByPlayer: new Map<string, MatchResultByPlayerEntry>(),
+          contributingVisibleScoresheets: new Map(),
+          contributingMatchIds: new Set<number>(),
         };
-        scoresheetMap.set(row.scoresheetParentId, scoresheet);
+        scoresheetMap.set(row.analyticsGroupingKey, scoresheet);
       }
 
-      let round = scoresheet.rounds.get(row.roundParentId);
+      const contributingKey = `${row.visibleScoresheetSourceType}-${row.visibleScoresheetId}`;
+      const contributor = scoresheet.contributingVisibleScoresheets.get(
+        contributingKey,
+      ) ?? {
+        visibleScoresheetId: row.visibleScoresheetId,
+        visibleScoresheetSourceType: row.visibleScoresheetSourceType,
+        name: row.visibleScoresheetName,
+        matchIds: new Set<number>(),
+      };
+      contributor.matchIds.add(row.matchId);
+      scoresheet.contributingVisibleScoresheets.set(
+        contributingKey,
+        contributor,
+      );
+      scoresheet.contributingMatchIds.add(row.matchId);
+
+      let round = scoresheet.rounds.get(row.analyticsGroupingRoundKey);
       if (!round) {
-        if (!row.roundParentName) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Round parent name is required",
-          });
-        }
         round = {
-          id: row.roundParentId,
-          name: row.roundParentName,
-          type: row.roundParentType,
-          order: row.roundOrder,
-          color: row.roundParentColor,
-          lookup: row.roundParentLookup,
-          modifier: row.roundParentModifier,
-          score: row.roundParentScore,
+          id: row.analyticsGroupingRoundId,
+          key: row.analyticsGroupingRoundKey,
+          name: row.analyticsRoundName,
+          type: row.analyticsRoundType,
+          order: row.analyticsRoundOrder,
+          color: row.analyticsRoundColor,
+          lookup: row.analyticsRoundLookup,
+          modifier: row.analyticsRoundModifier,
+          score: row.analyticsRoundScore,
           players: new Map<string, AggregatedRoundPlayer>(),
           allScores: [],
           allChecked: 0,
-          matchRounds: new Map<number, MatchRoundEntry[]>(),
           winningRoundScores: [],
           winningCheckedCount: 0,
           winningTotalPlays: 0,
         };
-        scoresheet.rounds.set(row.roundParentId, round);
+        scoresheet.rounds.set(row.analyticsGroupingRoundKey, round);
       }
 
-      const playerKey = `${row.playerType}-${row.playerId}`;
+      const playerType = sharedPlayerTypes.has(row.playerType)
+        ? "shared"
+        : "original";
+      const playerKey = `${playerType}-${row.playerId}`;
       let player = round.players.get(playerKey);
       if (!player) {
         player = {
@@ -415,12 +314,7 @@ class GameStatsService {
           playerSharedId: row.playerSharedId,
           playerLinkedId: row.playerLinkedId,
           name: row.playerName,
-          type:
-            row.playerType === "linked"
-              ? "shared"
-              : row.playerType === "not-shared"
-                ? "original"
-                : row.playerType,
+          type: playerType,
           scores: [],
           plays: 0,
         };
@@ -434,12 +328,10 @@ class GameStatsService {
         });
         player.plays++;
         round.allScores.push(row.roundPlayerScore);
-        // For checkbox rounds, count if checked (score > 0 or non-null)
         if (round.type === "Checkbox" && row.roundPlayerScore > 0) {
           round.allChecked++;
         }
       } else if (round.type === "Checkbox") {
-        // For checkbox, null might mean unchecked, but we still count the play
         player.scores.push({
           date: row.matchDate,
           score: null,
@@ -447,7 +339,6 @@ class GameStatsService {
         player.plays++;
       }
 
-      // Winning round stats: only when this player won the match
       if (row.matchPlayerWinner) {
         if (round.type === "Numeric" && row.roundPlayerScore !== null) {
           round.winningRoundScores.push(row.roundPlayerScore);
@@ -459,26 +350,6 @@ class GameStatsService {
         }
       }
 
-      // Track rounds per match for deciding round analysis
-      let matchRounds = round.matchRounds.get(row.matchId);
-      if (!matchRounds) {
-        matchRounds = [];
-        round.matchRounds.set(row.matchId, matchRounds);
-      }
-      let matchRound = matchRounds.find(
-        (mr) => mr.roundParentId === row.roundParentId,
-      );
-      if (!matchRound) {
-        matchRound = {
-          roundParentId: row.roundParentId,
-          roundOrder: row.roundOrder,
-          playerRounds: [],
-        };
-        matchRounds.push(matchRound);
-      }
-      matchRound.playerRounds.push({ score: row.roundPlayerScore });
-
-      // Track match-level result per player for overall scoresheet stats (final score, winner)
       let matchPlayerEntry = scoresheet.matchResultsByPlayer.get(playerKey);
       if (!matchPlayerEntry) {
         const image =
@@ -513,28 +384,16 @@ class GameStatsService {
 
   private calculateScoresheetStats(
     scoresheetMap: AggregatedScoresheetMap,
-    accessibleScoresheets: GetGameScoresheetStatsScoreSheetType,
   ): GetGameScoresheetStatsOutputType {
     const result: GetGameScoresheetStatsOutputType = [];
 
-    // Stats are keyed by canonical scoresheet id (parent or self); match each
-    // accessible scoresheet to its canonical stats and output one item per accessible entry.
-    for (const s of accessibleScoresheets) {
-      const scoresheet = scoresheetMap.get(s.canonicalScoresheetId);
-      if (!scoresheet) continue;
-
-      // Only include rounds that match this scoresheet's round list (linked or parent id).
-      const allowedRoundIds = new Set(s.rounds.map((r) => r.id));
-
+    for (const scoresheet of scoresheetMap.values()) {
       const rounds: GetGameScoresheetStatsRoundSchemaType[] = [];
 
-      for (const [roundId, round] of scoresheet.rounds) {
-        if (!allowedRoundIds.has(roundId)) continue;
-        // Calculate round-level stats based on round type
+      for (const round of scoresheet.rounds.values()) {
         let avgScore: number | null = null;
         let volatility: number | null = null;
         let checkRate: number | null = null;
-
         let winningAvgScore: number | null = null;
         let winningCheckRate: number | null = null;
 
@@ -578,7 +437,7 @@ class GameStatsService {
                 .filter((p): p is number => p !== null);
 
               if (validScores.length > 0) {
-                if (scoresheet.scoresheetWinCondition === "Lowest Score") {
+                if (scoresheet.winCondition === "Lowest Score") {
                   bestScore = Math.min(...validScores);
                   worstScore = Math.max(...validScores);
                 } else {
@@ -598,7 +457,7 @@ class GameStatsService {
 
             if (player.type === "original") {
               return {
-                type: "original" as const,
+                type: "original",
                 playerId: player.playerId,
                 name: player.name,
                 avgScore,
@@ -609,11 +468,14 @@ class GameStatsService {
                 scores: player.scores,
               };
             }
-            const sharedId = player.playerSharedId;
-            if (!sharedId) return null;
+
+            if (!player.playerSharedId) {
+              return null;
+            }
+
             return {
-              type: "shared" as const,
-              sharedId,
+              type: "shared",
+              sharedId: player.playerSharedId,
               name: player.name,
               avgScore,
               bestScore,
@@ -628,7 +490,7 @@ class GameStatsService {
           );
 
         rounds.push({
-          id: roundId,
+          id: round.id,
           name: round.name,
           type: round.type,
           order: round.order,
@@ -647,7 +509,6 @@ class GameStatsService {
 
       rounds.sort((a, b) => a.order - b.order);
 
-      // Overall stats per player: match count, wins, final score per match (N/A when no score)
       const overallPlayers: GetGameScoresheetStatsOverallPlayerSchemaType[] =
         [];
       for (const p of scoresheet.matchResultsByPlayer.values()) {
@@ -671,7 +532,7 @@ class GameStatsService {
         if (validScores.length > 0) {
           avgScore =
             validScores.reduce((a, b) => a + b, 0) / validScores.length;
-          if (scoresheet.scoresheetWinCondition === "Lowest Score") {
+          if (scoresheet.winCondition === "Lowest Score") {
             bestScore = Math.min(...validScores);
             worstScore = Math.max(...validScores);
           } else {
@@ -712,16 +573,6 @@ class GameStatsService {
         }
       }
 
-      const plays = (() => {
-        const matchIds = new Set<number>();
-        for (const p of scoresheet.matchResultsByPlayer.values()) {
-          for (const matchId of p.matches.keys()) {
-            matchIds.add(matchId);
-          }
-        }
-        return matchIds.size;
-      })();
-
       const allFinalScores: number[] = [];
       const winningFinalScores: number[] = [];
       for (const p of scoresheet.matchResultsByPlayer.values()) {
@@ -744,43 +595,74 @@ class GameStatsService {
             winningFinalScores.length
           : null;
 
-      if (s.type === "original") {
+      const contributingVisibleScoresheets = Array.from(
+        scoresheet.contributingVisibleScoresheets.values(),
+      )
+        .map((entry) => ({
+          visibleScoresheetId: entry.visibleScoresheetId,
+          visibleScoresheetSourceType: entry.visibleScoresheetSourceType,
+          name: entry.name,
+          matchCount: entry.matchIds.size,
+        }))
+        .toSorted((a, b) => a.name.localeCompare(b.name));
+
+      if (scoresheet.analyticsGroupingScoresheetSourceType === "local") {
         result.push({
           type: "original",
-          id: s.scoresheetId,
-          name: s.name,
-          isDefault: s.isDefault,
-          plays,
+          id: scoresheet.analyticsGroupingScoresheetId,
+          name: scoresheet.name,
+          isDefault: scoresheet.isDefault,
+          plays: scoresheet.contributingMatchIds.size,
           avgScore: sheetAvgScore,
           winningAvgScore: sheetWinningAvgScore,
-          winCondition: scoresheet.scoresheetWinCondition,
-          isCoop: s.isCoop,
-          roundsScore: scoresheet.scoresheetRoundsScore,
-          targetScore: s.targetScore,
+          analyticsGroupingScoresheetId:
+            scoresheet.analyticsGroupingScoresheetId,
+          analyticsGroupingScoresheetSourceType:
+            scoresheet.analyticsGroupingScoresheetSourceType,
+          analyticsGroupingKey: scoresheet.analyticsGroupingKey,
+          linkageState: scoresheet.linkageState,
+          contributingVisibleScoresheets,
+          contributingMatchCount: scoresheet.contributingMatchIds.size,
+          winCondition: scoresheet.winCondition,
+          isCoop: scoresheet.isCoop,
+          roundsScore: scoresheet.roundsScore,
+          targetScore: scoresheet.targetScore,
           players: overallPlayers,
           rounds,
         });
       } else {
         result.push({
           type: "shared",
-          sharedId: s.sharedId,
-          name: s.name,
-          permission: s.permission,
-          isDefault: s.isDefault,
-          plays,
+          sharedId: scoresheet.analyticsGroupingScoresheetId,
+          name: scoresheet.name,
+          permission: scoresheet.permission ?? "view",
+          isDefault: scoresheet.isDefault,
+          plays: scoresheet.contributingMatchIds.size,
           avgScore: sheetAvgScore,
           winningAvgScore: sheetWinningAvgScore,
-          winCondition: scoresheet.scoresheetWinCondition,
-          isCoop: s.isCoop,
-          roundsScore: scoresheet.scoresheetRoundsScore,
-          targetScore: s.targetScore,
+          analyticsGroupingScoresheetId:
+            scoresheet.analyticsGroupingScoresheetId,
+          analyticsGroupingScoresheetSourceType:
+            scoresheet.analyticsGroupingScoresheetSourceType,
+          analyticsGroupingKey: scoresheet.analyticsGroupingKey,
+          linkageState: scoresheet.linkageState,
+          contributingVisibleScoresheets,
+          contributingMatchCount: scoresheet.contributingMatchIds.size,
+          winCondition: scoresheet.winCondition,
+          isCoop: scoresheet.isCoop,
+          roundsScore: scoresheet.roundsScore,
+          targetScore: scoresheet.targetScore,
           players: overallPlayers,
           rounds,
         });
       }
     }
 
-    return result;
+    return result.toSorted((a, b) =>
+      a.name === b.name
+        ? a.analyticsGroupingKey.localeCompare(b.analyticsGroupingKey)
+        : a.name.localeCompare(b.name),
+    );
   }
 }
 

--- a/packages/api/src/services/game/game-stats.service.ts
+++ b/packages/api/src/services/game/game-stats.service.ts
@@ -1,7 +1,5 @@
 import { TRPCError } from "@trpc/server";
 
-import { db } from "@board-games/db/client";
-
 import type { GetGameStatsHeaderOutputType } from "../../repositories/game/game.repository.types";
 import type {
   GetGamePlayerStatsOutputType,
@@ -27,6 +25,7 @@ import type {
 } from "./game.service.types";
 import { gameStatsRepository } from "../../repositories/game/game-stats.repository";
 import { gameRepository } from "../../repositories/game/game.repository";
+import { playerRepository } from "../../repositories/player/player.repository";
 import { mapPlayerImageRowWithLogging } from "../../utils/image";
 
 const sharedPlayerTypes = new Set(["shared", "linked"]);
@@ -39,13 +38,10 @@ class GameStatsService {
 
     await this.assertGameAccessible(input, ctx.userId);
 
-    const userPlayer = await db.query.player.findFirst({
-      where: {
-        isUser: true,
-        createdBy: ctx.userId,
-      },
+    const userPlayerId = await playerRepository.getUserPlayerIdForUser({
+      userId: ctx.userId,
     });
-    if (!userPlayer) {
+    if (userPlayerId === null) {
       return {
         winRate: 0,
         avgPlaytime: 0,
@@ -60,7 +56,7 @@ class GameStatsService {
     const stats = await gameStatsRepository.getGameStatsHeaderData({
       input,
       userId: ctx.userId,
-      userPlayerId: userPlayer.id,
+      userPlayerId,
     });
 
     const winRate =
@@ -265,7 +261,7 @@ class GameStatsService {
         scoresheetMap.set(row.analyticsGroupingKey, scoresheet);
       }
 
-      const contributingKey = `${row.visibleScoresheetSourceType}-${row.visibleScoresheetId}`;
+      const contributingKey = `${row.visibleScoresheetSourceType}:${row.visibleScoresheetId}`;
       const contributor = scoresheet.contributingVisibleScoresheets.get(
         contributingKey,
       ) ?? {

--- a/packages/api/src/services/game/game-stats.service.types.ts
+++ b/packages/api/src/services/game/game-stats.service.types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 
-import { baseRoundSchema, scoreSheetSchema } from "@board-games/shared";
+import { scoreSheetSchema } from "@board-games/shared";
 
 // ---------------------------------------------------------------------------
 // getGamePlayerStats accumulator
@@ -41,7 +41,7 @@ export type GamePlayerStatsAccEntry =
   | GamePlayerStatsAccEntryShared;
 
 // ---------------------------------------------------------------------------
-// aggregateScoresheetData / calculateScoresheetStats
+// getGameScoresheetStats aggregation
 // ---------------------------------------------------------------------------
 
 export interface RoundPlayerScore {
@@ -59,12 +59,6 @@ export interface AggregatedRoundPlayer {
   plays: number;
 }
 
-export interface MatchRoundEntry {
-  roundParentId: number;
-  roundOrder: number;
-  playerRounds: { score: number | null }[];
-}
-
 export type ScoresheetRoundsScoreType = NonNullable<
   z.infer<typeof scoreSheetSchema>["roundsScore"]
 >;
@@ -74,6 +68,7 @@ export type ScoresheetWinConditionType = NonNullable<
 
 export interface AggregatedRound {
   id: number;
+  key: string;
   name: string;
   type: "Numeric" | "Checkbox";
   order: number;
@@ -84,12 +79,8 @@ export interface AggregatedRound {
   players: Map<string, AggregatedRoundPlayer>;
   allScores: number[];
   allChecked: number;
-  matchRounds: Map<number, MatchRoundEntry[]>;
-  /** Numeric: round scores when the player won the match. */
   winningRoundScores: number[];
-  /** Checkbox: count of winning performances where this round was checked. */
   winningCheckedCount: number;
-  /** Checkbox: total winning performances for this round. */
   winningTotalPlays: number;
 }
 
@@ -114,47 +105,29 @@ export interface MatchResultByPlayerEntry {
   matches: Map<number, MatchResult>;
 }
 
-export interface AggregatedScoresheet {
-  id: number;
+export interface ContributingVisibleScoresheet {
+  visibleScoresheetId: number;
+  visibleScoresheetSourceType: "local" | "shared";
   name: string;
-  rounds: Map<number, AggregatedRound>;
-  scoresheetRoundsScore: ScoresheetRoundsScoreType;
-  scoresheetWinCondition: ScoresheetWinConditionType;
-  matchResultsByPlayer: Map<string, MatchResultByPlayerEntry>;
+  matchIds: Set<number>;
 }
 
-export type AggregatedScoresheetMap = Map<number, AggregatedScoresheet>;
+export interface AggregatedScoresheetFamily {
+  analyticsGroupingScoresheetId: number;
+  analyticsGroupingScoresheetSourceType: "local" | "shared";
+  analyticsGroupingKey: string;
+  linkageState: "original" | "shared_unlinked" | "shared_linked";
+  name: string;
+  isCoop: boolean;
+  targetScore: number;
+  roundsScore: ScoresheetRoundsScoreType;
+  winCondition: ScoresheetWinConditionType;
+  isDefault: boolean;
+  permission: "view" | "edit" | null;
+  rounds: Map<string, AggregatedRound>;
+  matchResultsByPlayer: Map<string, MatchResultByPlayerEntry>;
+  contributingVisibleScoresheets: Map<string, ContributingVisibleScoresheet>;
+  contributingMatchIds: Set<number>;
+}
 
-// ---------------------------------------------------------------------------
-// getGameScoresheetStats accessible scoresheets (Zod)
-// ---------------------------------------------------------------------------
-
-const parenRoundSchema = baseRoundSchema.extend({
-  id: z.number(),
-});
-
-const getGameScoresheetStatsScoreSheet = z.array(
-  z.discriminatedUnion("type", [
-    scoreSheetSchema.safeExtend({
-      type: z.literal("original"),
-      scoresheetId: z.number(),
-      /** Canonical scoresheet id for stats grouping (parent or self). */
-      canonicalScoresheetId: z.number(),
-      isDefault: z.boolean(),
-      rounds: z.array(parenRoundSchema),
-    }),
-    scoreSheetSchema.safeExtend({
-      type: z.literal("shared"),
-      scoresheetId: z.number(),
-      /** Canonical scoresheet id for stats grouping (owner template parent or self). */
-      canonicalScoresheetId: z.number(),
-      sharedId: z.number(),
-      permission: z.literal("view").or(z.literal("edit")),
-      isDefault: z.boolean(),
-      rounds: z.array(parenRoundSchema),
-    }),
-  ]),
-);
-export type GetGameScoresheetStatsScoreSheetType = z.infer<
-  typeof getGameScoresheetStatsScoreSheet
->;
+export type AggregatedScoresheetMap = Map<string, AggregatedScoresheetFamily>;

--- a/packages/api/src/services/game/game-stats.service.types.ts
+++ b/packages/api/src/services/game/game-stats.service.types.ts
@@ -126,6 +126,7 @@ export interface AggregatedScoresheetFamily {
   permission: "view" | "edit" | null;
   rounds: Map<string, AggregatedRound>;
   matchResultsByPlayer: Map<string, MatchResultByPlayerEntry>;
+  /** Key format is `<sourceType>:<visibleScoresheetId>`, for example `local:12` or `shared:34`. */
   contributingVisibleScoresheets: Map<string, ContributingVisibleScoresheet>;
   contributingMatchIds: Set<number>;
 }

--- a/packages/api/src/services/game/game.service.types.ts
+++ b/packages/api/src/services/game/game.service.types.ts
@@ -2,7 +2,10 @@ import type {
   CreateGameInputType,
   EditGameInputType,
   GetGameInputType,
+  GetSharedScoresheetAnalyticsLinkStateInputType,
   ImportBGGGamesInputType,
+  LinkSharedRoundsAnalyticsInputType,
+  LinkSharedScoresheetAnalyticsInputType,
 } from "../../routers/game/game.input";
 import type {
   PosthogUserCtx,
@@ -43,3 +46,12 @@ export type GetGamePlayerStatsArgs = WithPosthogUserCtx<GetGameInputType>;
 export type GetGameScoresheetStatsArgs = WithUserIdCtx<GetGameInputType>;
 
 export type GetGameInsightsArgs = WithUserIdCtx<GetGameInputType>;
+
+export type GetSharedScoresheetAnalyticsLinkStateArgs =
+  WithUserIdCtx<GetSharedScoresheetAnalyticsLinkStateInputType>;
+
+export type LinkSharedScoresheetAnalyticsArgs =
+  WithUserIdCtx<LinkSharedScoresheetAnalyticsInputType>;
+
+export type LinkSharedRoundsAnalyticsArgs =
+  WithUserIdCtx<LinkSharedRoundsAnalyticsInputType>;

--- a/packages/api/src/services/match/match-setup.service.ts
+++ b/packages/api/src/services/match/match-setup.service.ts
@@ -101,13 +101,14 @@ class MatchSetupService {
     scoresheetInput: CreateMatchArgs["input"]["scoresheet"];
     userId: string;
     gameId: number;
+    sharedGameId?: number;
     tx: TransactionType;
   }): Promise<{
     id: number;
     rounds: { id: number }[];
     type: "Match";
   }> {
-    const { scoresheetInput, userId, gameId, tx } = args;
+    const { scoresheetInput, userId, gameId, sharedGameId, tx } = args;
     if (scoresheetInput.type === "original") {
       return this.resolveOriginalScoresheet({
         scoresheetInput,
@@ -121,6 +122,7 @@ class MatchSetupService {
         scoresheetInput,
         userId,
         gameId,
+        sharedGameId,
         tx,
       });
     }
@@ -194,17 +196,26 @@ class MatchSetupService {
     >;
     userId: string;
     gameId: number;
+    sharedGameId?: number;
     tx: TransactionType;
   }): Promise<{
     id: number;
     rounds: { id: number }[];
     type: "Match";
   }> {
-    const { scoresheetInput, userId, gameId, tx } = args;
+    const { scoresheetInput, userId, gameId, sharedGameId, tx } = args;
+    if (sharedGameId === undefined) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message:
+          "Shared scoresheet resolution requires the selected shared game.",
+      });
+    }
     const returnedSharedScoresheet =
       await scoresheetRepository.getSharedForMaterialization({
         input: {
           sharedScoresheetId: scoresheetInput.sharedId,
+          sharedGameId,
           userId,
         },
         tx,
@@ -280,100 +291,124 @@ class MatchSetupService {
     }
 
     if (localOriginalId === null) {
-      const localOriginal = await scoresheetRepository.insert(
-        {
-          name: returnedSharedScoresheet.scoresheet.name,
-          isCoop: returnedSharedScoresheet.scoresheet.isCoop,
-          winCondition: returnedSharedScoresheet.scoresheet.winCondition,
-          targetScore: returnedSharedScoresheet.scoresheet.targetScore,
-          roundsScore: returnedSharedScoresheet.scoresheet.roundsScore,
-          forkedFromScoresheetId: returnedSharedScoresheet.scoresheet.id,
-          forkedFromSharedScoresheetId: returnedSharedScoresheet.id,
-          forkedFromTemplateVersion:
-            returnedSharedScoresheet.scoresheet.templateVersion,
-          scoresheetKey: returnedSharedScoresheet.scoresheet.scoresheetKey,
-          createdBy: userId,
-          gameId,
-          type: "Game",
-        },
-        tx,
-      );
+      const localOriginalResult =
+        await scoresheetRepository.insertMaterializedLocalScoresheetIfAbsent(
+          {
+            name: returnedSharedScoresheet.scoresheet.name,
+            isCoop: returnedSharedScoresheet.scoresheet.isCoop,
+            winCondition: returnedSharedScoresheet.scoresheet.winCondition,
+            targetScore: returnedSharedScoresheet.scoresheet.targetScore,
+            roundsScore: returnedSharedScoresheet.scoresheet.roundsScore,
+            forkedFromScoresheetId: returnedSharedScoresheet.scoresheet.id,
+            forkedFromSharedScoresheetId: returnedSharedScoresheet.id,
+            forkedFromTemplateVersion:
+              returnedSharedScoresheet.scoresheet.templateVersion,
+            scoresheetKey: returnedSharedScoresheet.scoresheet.scoresheetKey,
+            createdBy: userId,
+            gameId,
+            type: "Game",
+          },
+          tx,
+        );
       assertInserted(
-        localOriginal,
+        localOriginalResult,
         { userId, value: scoresheetInput },
         "Scoresheet Not Created Successfully. For Create Match. Based on Shared Scoresheet.",
       );
-      localOriginalId = localOriginal.id;
+      localOriginalId = localOriginalResult.scoresheet.id;
 
-      const newScoresheetRounds = await this.insertRoundsFromTemplate(
-        returnedSharedScoresheet.sharedRounds.map((sr) => sr.round),
-        localOriginalId,
-        tx,
-      );
-      if (
-        newScoresheetRounds.length !==
-        returnedSharedScoresheet.sharedRounds.length
-      ) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            "Rounds not inserted successfully for linked scoresheet. For Create Match. Based on Shared Scoresheet.",
+      if (localOriginalResult.wasInserted) {
+        const newScoresheetRounds = await this.insertRoundsFromTemplate(
+          returnedSharedScoresheet.sharedRounds.map((sr) => sr.round),
+          localOriginalId,
+          tx,
+        );
+        if (
+          newScoresheetRounds.length !==
+          returnedSharedScoresheet.sharedRounds.length
+        ) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "Rounds not inserted successfully for linked scoresheet. For Create Match. Based on Shared Scoresheet.",
+          });
+        }
+
+        const copiedRoundLinks = returnedSharedScoresheet.sharedRounds.map(
+          (sharedRound) => {
+            const newRound = newScoresheetRounds.find(
+              (round) => round.parentId === sharedRound.round.id,
+            );
+            if (!newRound) {
+              throw new TRPCError({
+                code: "INTERNAL_SERVER_ERROR",
+                message: `New round not found for shared round ${String(sharedRound.id)} (template round ${String(sharedRound.round.id)}). For Create Match. Based on Shared Scoresheet.`,
+              });
+            }
+            return {
+              sharedRoundId: sharedRound.id,
+              linkedRoundId: newRound.id,
+            };
+          },
+        );
+
+        await scoresheetRepository.linkSharedScoresheetAnalytics({
+          input: {
+            sharedScoresheetId: returnedSharedScoresheet.id,
+            linkedScoresheetId: localOriginalId,
+            sharedWithId: userId,
+          },
+          tx,
         });
-      }
 
-      const copiedRoundLinks = returnedSharedScoresheet.sharedRounds.map(
-        (sharedRound) => {
-          const newRound = newScoresheetRounds.find(
-            (round) => round.parentId === sharedRound.round.id,
+        await roundRepository.bulkLinkSharedRoundsAnalytics({
+          input: {
+            sharedScoresheetId: returnedSharedScoresheet.id,
+            linkedScoresheetId: localOriginalId,
+            links: copiedRoundLinks,
+          },
+          tx,
+        });
+
+        await scoresheetRepository.setLegacyLinkedScoresheetIdIfNeeded({
+          input: {
+            sharedScoresheetId: returnedSharedScoresheet.id,
+            linkedScoresheetId: localOriginalId,
+          },
+          tx,
+        });
+
+        await roundRepository.setLegacyLinkedRoundIdIfNeeded({
+          input: {
+            links: copiedRoundLinks.filter(
+              (
+                link,
+              ): link is { sharedRoundId: number; linkedRoundId: number } =>
+                link.linkedRoundId !== null,
+            ),
+          },
+          tx,
+        });
+      } else {
+        const existingLocalOriginal =
+          await scoresheetRepository.getMaterializedLocalScoresheetForSharedScoresheet(
+            {
+              input: {
+                sharedScoresheetId: returnedSharedScoresheet.id,
+                userId,
+              },
+              tx,
+            },
           );
-          if (!newRound) {
-            throw new TRPCError({
-              code: "INTERNAL_SERVER_ERROR",
-              message: `New round not found for shared round ${String(sharedRound.id)} (template round ${String(sharedRound.round.id)}). For Create Match. Based on Shared Scoresheet.`,
-            });
-          }
-          return {
-            sharedRoundId: sharedRound.id,
-            linkedRoundId: newRound.id,
-          };
-        },
-      );
 
-      await scoresheetRepository.linkSharedScoresheetAnalytics({
-        input: {
-          sharedScoresheetId: returnedSharedScoresheet.id,
-          linkedScoresheetId: localOriginalId,
-          sharedWithId: userId,
-        },
-        tx,
-      });
+        assertFound(
+          existingLocalOriginal,
+          { userId, value: scoresheetInput },
+          "Materialized local scoresheet not found after upsert conflict.",
+        );
 
-      await roundRepository.bulkLinkSharedRoundsAnalytics({
-        input: {
-          sharedScoresheetId: returnedSharedScoresheet.id,
-          linkedScoresheetId: localOriginalId,
-          links: copiedRoundLinks,
-        },
-        tx,
-      });
-
-      await scoresheetRepository.setLegacyLinkedScoresheetIdIfNeeded({
-        input: {
-          sharedScoresheetId: returnedSharedScoresheet.id,
-          linkedScoresheetId: localOriginalId,
-        },
-        tx,
-      });
-
-      await roundRepository.setLegacyLinkedRoundIdIfNeeded({
-        input: {
-          links: copiedRoundLinks.filter(
-            (link): link is { sharedRoundId: number; linkedRoundId: number } =>
-              link.linkedRoundId !== null,
-          ),
-        },
-        tx,
-      });
+        localOriginalId = existingLocalOriginal.id;
+      }
     }
 
     return this.resolveOriginalScoresheet({

--- a/packages/api/src/services/match/match-setup.service.ts
+++ b/packages/api/src/services/match/match-setup.service.ts
@@ -201,105 +201,178 @@ class MatchSetupService {
     type: "Match";
   }> {
     const { scoresheetInput, userId, gameId, tx } = args;
-    const returnedSharedScoresheet = await scoresheetRepository.getShared(
-      {
-        id: scoresheetInput.sharedId,
-        sharedWithId: userId,
-        with: {
-          scoresheet: true,
-          sharedRounds: { with: { round: true } },
+    const returnedSharedScoresheet =
+      await scoresheetRepository.getSharedForMaterialization({
+        input: {
+          sharedScoresheetId: scoresheetInput.sharedId,
+          userId,
         },
-      },
-      tx,
-    );
+        tx,
+      });
     assertFound(
       returnedSharedScoresheet,
       { userId, value: scoresheetInput },
       "Shared scoresheet not found. For Create Match",
     );
-    if (returnedSharedScoresheet.linkedScoresheetId !== null) {
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message:
-          "Shared scoresheet already has a linked copy. Cannot create another match from this shared scoresheet.",
-      });
-    }
-    const insertedNewScoresheet = await scoresheetRepository.insert(
-      {
-        name: returnedSharedScoresheet.scoresheet.name,
-        isCoop: returnedSharedScoresheet.scoresheet.isCoop,
-        winCondition: returnedSharedScoresheet.scoresheet.winCondition,
-        targetScore: returnedSharedScoresheet.scoresheet.targetScore,
-        roundsScore: returnedSharedScoresheet.scoresheet.roundsScore,
-        forkedFromScoresheetId: returnedSharedScoresheet.scoresheet.id,
-        forkedFromTemplateVersion:
-          returnedSharedScoresheet.scoresheet.templateVersion,
-        scoresheetKey: returnedSharedScoresheet.scoresheet.scoresheetKey,
-        createdBy: userId,
-        gameId,
-        type: "Game",
-      },
-      tx,
-    );
-    assertInserted(
-      insertedNewScoresheet,
-      { userId, value: scoresheetInput },
-      "Scoresheet Not Created Successfully. For Create Match. Based on Shared Scoresheet.",
-    );
-    const newScoresheetRounds = await this.insertRoundsFromTemplate(
-      returnedSharedScoresheet.sharedRounds.map((sr) => sr.round),
-      insertedNewScoresheet.id,
-      tx,
-    );
-    if (
-      newScoresheetRounds.length !==
-      returnedSharedScoresheet.sharedRounds.length
-    ) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          "Rounds not inserted successfully for linked scoresheet. For Create Match. Based on Shared Scoresheet.",
-      });
-    }
-    for (const sharedRound of returnedSharedScoresheet.sharedRounds) {
-      const newRound = newScoresheetRounds.find(
-        (r) => r.parentId === sharedRound.round.id,
+
+    let localOriginalId: number | null = null;
+    const existingLocalOriginal =
+      await scoresheetRepository.getMaterializedLocalScoresheetForSharedScoresheet(
+        {
+          input: {
+            sharedScoresheetId: returnedSharedScoresheet.id,
+            userId,
+          },
+          tx,
+        },
       );
-      if (!newRound) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: `New round not found for shared round ${String(sharedRound.id)} (template round ${String(sharedRound.round.id)}). For Create Match. Based on Shared Scoresheet.`,
+
+    if (existingLocalOriginal) {
+      localOriginalId = existingLocalOriginal.id;
+      if (
+        existingLocalOriginal.forkedFromSharedScoresheetId !==
+        returnedSharedScoresheet.id
+      ) {
+        await scoresheetRepository.update({
+          input: {
+            id: existingLocalOriginal.id,
+            forkedFromSharedScoresheetId: returnedSharedScoresheet.id,
+          },
+          tx,
         });
       }
-      const linkedSharedRound = await roundRepository.linkSharedRound({
-        input: {
+
+      if (
+        returnedSharedScoresheet.analyticsLinkedScoresheetId !==
+        existingLocalOriginal.id
+      ) {
+        await scoresheetRepository.linkSharedScoresheetAnalytics({
+          input: {
+            sharedScoresheetId: returnedSharedScoresheet.id,
+            linkedScoresheetId: existingLocalOriginal.id,
+          },
+          tx,
+        });
+      }
+
+      const missingAnalyticsRoundLinks = returnedSharedScoresheet.sharedRounds
+        .filter(
+          (sharedRound) =>
+            sharedRound.analyticsLinkedRoundId === null &&
+            sharedRound.linkedRoundId !== null,
+        )
+        .map((sharedRound) => ({
           sharedRoundId: sharedRound.id,
-          linkedRoundId: newRound.id,
-          sharedScoresheetId: sharedRound.sharedScoresheetId,
+          linkedRoundId: sharedRound.linkedRoundId,
+        }));
+
+      if (missingAnalyticsRoundLinks.length > 0) {
+        await roundRepository.bulkLinkSharedRoundsAnalytics({
+          input: {
+            links: missingAnalyticsRoundLinks,
+          },
+          tx,
+        });
+      }
+    }
+
+    if (localOriginalId === null) {
+      const localOriginal = await scoresheetRepository.insert(
+        {
+          name: returnedSharedScoresheet.scoresheet.name,
+          isCoop: returnedSharedScoresheet.scoresheet.isCoop,
+          winCondition: returnedSharedScoresheet.scoresheet.winCondition,
+          targetScore: returnedSharedScoresheet.scoresheet.targetScore,
+          roundsScore: returnedSharedScoresheet.scoresheet.roundsScore,
+          forkedFromScoresheetId: returnedSharedScoresheet.scoresheet.id,
+          forkedFromSharedScoresheetId: returnedSharedScoresheet.id,
+          forkedFromTemplateVersion:
+            returnedSharedScoresheet.scoresheet.templateVersion,
+          scoresheetKey: returnedSharedScoresheet.scoresheet.scoresheetKey,
+          createdBy: userId,
+          gameId,
+          type: "Game",
+        },
+        tx,
+      );
+      assertInserted(
+        localOriginal,
+        { userId, value: scoresheetInput },
+        "Scoresheet Not Created Successfully. For Create Match. Based on Shared Scoresheet.",
+      );
+      localOriginalId = localOriginal.id;
+
+      const newScoresheetRounds = await this.insertRoundsFromTemplate(
+        returnedSharedScoresheet.sharedRounds.map((sr) => sr.round),
+        localOriginalId,
+        tx,
+      );
+      if (
+        newScoresheetRounds.length !==
+        returnedSharedScoresheet.sharedRounds.length
+      ) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message:
+            "Rounds not inserted successfully for linked scoresheet. For Create Match. Based on Shared Scoresheet.",
+        });
+      }
+
+      const copiedRoundLinks = returnedSharedScoresheet.sharedRounds.map(
+        (sharedRound) => {
+          const newRound = newScoresheetRounds.find(
+            (round) => round.parentId === sharedRound.round.id,
+          );
+          if (!newRound) {
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: `New round not found for shared round ${String(sharedRound.id)} (template round ${String(sharedRound.round.id)}). For Create Match. Based on Shared Scoresheet.`,
+            });
+          }
+          return {
+            sharedRoundId: sharedRound.id,
+            linkedRoundId: newRound.id,
+          };
+        },
+      );
+
+      await scoresheetRepository.linkSharedScoresheetAnalytics({
+        input: {
+          sharedScoresheetId: returnedSharedScoresheet.id,
+          linkedScoresheetId: localOriginalId,
         },
         tx,
       });
-      assertInserted(
-        linkedSharedRound,
-        { userId, value: scoresheetInput },
-        "Shared round not linked successfully. For Create Match. Based on Shared Scoresheet.",
-      );
+
+      await roundRepository.bulkLinkSharedRoundsAnalytics({
+        input: {
+          links: copiedRoundLinks,
+        },
+        tx,
+      });
+
+      await scoresheetRepository.setLegacyLinkedScoresheetIdIfNeeded({
+        input: {
+          sharedScoresheetId: returnedSharedScoresheet.id,
+          linkedScoresheetId: localOriginalId,
+        },
+        tx,
+      });
+
+      await roundRepository.setLegacyLinkedRoundIdIfNeeded({
+        input: {
+          links: copiedRoundLinks.filter(
+            (link): link is { sharedRoundId: number; linkedRoundId: number } =>
+              link.linkedRoundId !== null,
+          ),
+        },
+        tx,
+      });
     }
-    const linkScoresheet = await scoresheetRepository.linkSharedScoresheet({
-      input: {
-        sharedScoresheetId: returnedSharedScoresheet.id,
-        linkedScoresheetId: insertedNewScoresheet.id,
-      },
-      tx,
-    });
-    assertInserted(
-      linkScoresheet,
-      { userId, value: scoresheetInput },
-      "Scoresheet Not Linked Successfully. For Create Match. Based on Shared Scoresheet.",
-    );
+
     return this.resolveOriginalScoresheet({
       scoresheetInput: {
-        id: insertedNewScoresheet.id,
+        id: localOriginalId,
         type: "original",
       },
       userId,

--- a/packages/api/src/services/match/match-setup.service.ts
+++ b/packages/api/src/services/match/match-setup.service.ts
@@ -250,6 +250,7 @@ class MatchSetupService {
           input: {
             sharedScoresheetId: returnedSharedScoresheet.id,
             linkedScoresheetId: existingLocalOriginal.id,
+            sharedWithId: userId,
           },
           tx,
         });
@@ -269,6 +270,8 @@ class MatchSetupService {
       if (missingAnalyticsRoundLinks.length > 0) {
         await roundRepository.bulkLinkSharedRoundsAnalytics({
           input: {
+            sharedScoresheetId: returnedSharedScoresheet.id,
+            linkedScoresheetId: existingLocalOriginal.id,
             links: missingAnalyticsRoundLinks,
           },
           tx,
@@ -340,12 +343,15 @@ class MatchSetupService {
         input: {
           sharedScoresheetId: returnedSharedScoresheet.id,
           linkedScoresheetId: localOriginalId,
+          sharedWithId: userId,
         },
         tx,
       });
 
       await roundRepository.bulkLinkSharedRoundsAnalytics({
         input: {
+          sharedScoresheetId: returnedSharedScoresheet.id,
+          linkedScoresheetId: localOriginalId,
           links: copiedRoundLinks,
         },
         tx,

--- a/packages/api/src/services/match/match.service.ts
+++ b/packages/api/src/services/match/match.service.ts
@@ -55,6 +55,8 @@ class MatchService {
           scoresheetInput: input.scoresheet,
           userId,
           gameId,
+          sharedGameId:
+            input.game.type === "shared" ? input.game.sharedGameId : undefined,
           tx,
         });
         if (matchScoresheet.type !== "Match") {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -25,7 +25,7 @@ if (!process.env.NODE_ENV || !process.env.POSTGRES_URL) {
 }
 
 export const db =
-  process.env.NODE_ENV === "development"
+  process.env.NODE_ENV !== "production"
     ? LocalDrizzle({
         client: pool,
         relations,

--- a/packages/db/src/migrations/0006_user_scoped_scoresheet_analytics.sql
+++ b/packages/db/src/migrations/0006_user_scoped_scoresheet_analytics.sql
@@ -1,244 +1,45 @@
--- ============================================================
--- DROP VIEWS (CASCADE to handle dependencies)
--- ============================================================
-DROP VIEW IF EXISTS v_game_match_overview CASCADE;
-DROP VIEW IF EXISTS v_game_role_canonical CASCADE;
-DROP VIEW IF EXISTS v_match_canonical CASCADE;
-DROP VIEW IF EXISTS v_match_player_canonical_for_user CASCADE;
+ALTER TABLE "boardgames_scoresheet"
+  ADD COLUMN IF NOT EXISTS "forked_from_shared_scoresheet_id" integer;
+--> statement-breakpoint
+ALTER TABLE "boardgames_shared_scoresheet"
+  ADD COLUMN IF NOT EXISTS "analytics_linked_scoresheet_id" integer;
+--> statement-breakpoint
+ALTER TABLE "boardgames_shared_round"
+  ADD COLUMN IF NOT EXISTS "analytics_linked_round_id" integer;
+--> statement-breakpoint
+ALTER TABLE "boardgames_scoresheet"
+  ADD CONSTRAINT "boardgames_scoresheet_forked_from_shared_scoresheet_id_boardgames_shared_scoresheet_id_fk"
+  FOREIGN KEY ("forked_from_shared_scoresheet_id")
+  REFERENCES "public"."boardgames_shared_scoresheet"("id")
+  ON DELETE no action
+  ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "boardgames_shared_scoresheet"
+  ADD CONSTRAINT "boardgames_shared_scoresheet_analytics_linked_scoresheet_id_boardgames_scoresheet_id_fk"
+  FOREIGN KEY ("analytics_linked_scoresheet_id")
+  REFERENCES "public"."boardgames_scoresheet"("id")
+  ON DELETE no action
+  ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "boardgames_shared_round"
+  ADD CONSTRAINT "boardgames_shared_round_analytics_linked_round_id_boardgames_round_id_fk"
+  FOREIGN KEY ("analytics_linked_round_id")
+  REFERENCES "public"."boardgames_round"("id")
+  ON DELETE no action
+  ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "boardgames_scoresheet_forked_from_shared_scoresheet_id_index"
+  ON "boardgames_scoresheet" USING btree ("forked_from_shared_scoresheet_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "boardgames_shared_scoresheet_analytics_linked_scoresheet_id_index"
+  ON "boardgames_shared_scoresheet" USING btree ("analytics_linked_scoresheet_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "boardgames_shared_round_analytics_linked_round_id_index"
+  ON "boardgames_shared_round" USING btree ("analytics_linked_round_id");
+--> statement-breakpoint
 DROP VIEW IF EXISTS v_round_analytics_for_user CASCADE;
 DROP VIEW IF EXISTS v_scoresheet_analytics_for_user CASCADE;
-
--- ============================================================
--- RECREATE v_match_canonical
--- ============================================================
-CREATE OR REPLACE VIEW v_match_canonical AS
--- A) Owner-visible originals
-SELECT
-  m.id AS match_id,
-  m.name AS name,
-  m.comment AS comment,
-  m.created_by AS owner_id,
-  m.created_by AS visible_to_user_id,
-  m.game_id AS canonical_game_id,
-  NULL AS linked_game_id,
-  NULL AS shared_game_id,
-  NULL AS shared_match_id,
-  m.scoresheet_id AS canonical_scoresheet_id,
-  m.location_id AS canonical_location_id,
-  m.date AS match_date,
-  m.finished AS finished,
-  'original'::text AS visibility_source,
-  'original'::text AS game_visibility_source,
-  'edit'::text AS permission
-FROM boardgames_match m
-WHERE m.deleted_at IS NULL
-
-UNION ALL
-
--- B) Receiver-visible shared
-SELECT
-  m.id AS match_id,
-  m.name AS name,
-  m.comment AS comment,
-  m.created_by AS owner_id,
-  sm.shared_with_id AS visible_to_user_id,
-  COALESCE(sg.linked_game_id, m.game_id) AS canonical_game_id,
-  sg.linked_game_id AS linked_game_id,
-  sg.id AS shared_game_id,
-  sm.id AS shared_match_id,
-  COALESCE(ss.linked_scoresheet_id, m.scoresheet_id) AS canonical_scoresheet_id,
-  COALESCE(sl.linked_location_id, m.location_id) AS canonical_location_id,
-  m.date AS match_date,
-  m.finished AS finished,
-  'shared'::text AS visibility_source,
-  CASE WHEN sg.linked_game_id IS NULL THEN 'shared'::text ELSE 'linked'::text END AS game_visibility_source,
-  sm.permission::text AS permission
-FROM boardgames_match m
-JOIN boardgames_shared_match sm ON sm.match_id = m.id
-LEFT JOIN boardgames_shared_game sg
-  ON sg.id = sm.shared_game_id AND sg.shared_with_id = sm.shared_with_id
-LEFT JOIN boardgames_shared_scoresheet ss
-  ON ss.id = sm.shared_scoresheet_id AND ss.shared_with_id = sm.shared_with_id
-LEFT JOIN boardgames_shared_location sl
-  ON sl.id = sm.shared_location_id AND sl.shared_with_id = sm.shared_with_id
-WHERE m.deleted_at IS NULL;
-
--- ============================================================
--- RECREATE v_game_role_canonical
--- ============================================================
-CREATE OR REPLACE VIEW v_game_role_canonical AS
--- Original roles (owner-visible)
-SELECT
-  g.id AS canonical_game_id,
-  gr.id AS canonical_game_role_id,
-  gr.id AS original_game_role_id,
-  NULL::INTEGER AS linked_game_role_id,
-  NULL::INTEGER AS shared_game_role_id,
-  g.created_by AS owner_id,
-  g.created_by AS visible_to_user_id,
-  'original'::text AS source_type,
-  'edit'::text AS permission,
-  gr.name AS name,
-  gr.description AS description
-FROM boardgames_game_role gr
-JOIN boardgames_game g ON g.id = gr.game_id
-WHERE gr.deleted_at IS NULL
-  AND g.deleted_at IS NULL
-
-UNION ALL
-
--- Shared roles (recipient-visible)
-SELECT
-  COALESCE(sg.linked_game_id, sg.game_id) AS canonical_game_id,
-  COALESCE(lgr.id, gr.id) AS canonical_game_role_id,
-  gr.id AS original_game_role_id,
-  lgr.id AS linked_game_role_id,
-  sgr.id AS shared_game_role_id,
-  sg.owner_id AS owner_id,
-  sg.shared_with_id AS visible_to_user_id,
-  CASE WHEN lgr.id IS NULL THEN 'shared'::text ELSE 'linked'::text END AS source_type,
-  sgr.permission AS permission,
-  COALESCE(lgr.name, gr.name) AS name,
-  COALESCE(lgr.description, gr.description) AS description
-FROM boardgames_shared_game_role sgr
-JOIN boardgames_shared_game sg ON sg.id = sgr.shared_game_id
-LEFT JOIN boardgames_game_role gr ON gr.id = sgr.game_role_id
-LEFT JOIN boardgames_game_role lgr ON lgr.id = sgr.linked_game_role_id
-WHERE sg.shared_with_id IS NOT NULL
-  AND COALESCE(lgr.deleted_at, gr.deleted_at) IS NULL
-  AND (gr.id IS NOT NULL OR lgr.id IS NOT NULL);
-
--- ============================================================
--- RECREATE v_match_player_canonical_for_user
--- ============================================================
-CREATE OR REPLACE VIEW v_match_player_canonical_for_user AS
-WITH unioned AS (
-  -- ----------------------------------------------------------
-  -- ORIGINAL rows
-  -- ----------------------------------------------------------
-  SELECT
-    mp.id AS base_match_player_id,
-    mp.match_id AS canonical_match_id,
-    mp.player_id AS canonical_player_id,
-    mp.player_id AS original_player_id,
-    NULL::INTEGER AS linked_player_id,
-    NULL::INTEGER AS shared_player_id,
-    NULL::INTEGER AS shared_match_player_id,
-    m.created_by AS owner_id,
-    NULL::text AS shared_with_id,
-    'original'::text AS source_type,
-    'original'::text AS player_source_type,
-    'edit'::text AS permission,
-    mp.team_id AS team_id,
-    mp.score AS score,
-    mp.winner::BOOLEAN AS winner,
-    mp.placement AS placement,
-    mp.created_at AS created_at,
-    mp.updated_at AS updated_at
-  FROM boardgames_match_player mp
-  JOIN boardgames_match m ON m.id = mp.match_id
-  WHERE m.deleted_at IS NULL
-
-  UNION ALL
-
-  -- ----------------------------------------------------------
-  -- SHARED rows
-  -- ----------------------------------------------------------
-  SELECT
-    mp.id AS base_match_player_id,
-    sm.match_id AS canonical_match_id,
-    COALESCE(sp.linked_player_id, mp.player_id) AS canonical_player_id,
-    mp.player_id AS original_player_id,
-    sp.linked_player_id AS linked_player_id,
-    sp.id AS shared_player_id,
-    smp.id AS shared_match_player_id,
-    m.created_by AS owner_id,
-    sm.shared_with_id AS shared_with_id,
-    'shared'::text AS source_type,
-    CASE
-      WHEN sp.linked_player_id IS NOT NULL THEN 'linked'::text
-      WHEN smp.shared_player_id IS NOT NULL THEN 'shared'::text
-      ELSE 'not-shared'::text
-    END AS player_source_type,
-    smp.permission::text AS permission,
-    mp.team_id AS team_id,
-    mp.score AS score,
-    mp.winner::BOOLEAN AS winner,
-    mp.placement AS placement,
-    smp.created_at AS created_at,
-    smp.updated_at AS updated_at
-  FROM boardgames_shared_match sm
-  JOIN boardgames_match m ON m.id = sm.match_id
-  JOIN boardgames_shared_match_player smp ON smp.shared_match_id = sm.id
-  JOIN boardgames_match_player mp ON mp.id = smp.match_player_id
-  LEFT JOIN boardgames_shared_player sp ON sp.id = smp.shared_player_id
-  WHERE m.deleted_at IS NULL
-)
-
-SELECT DISTINCT ON (base_match_player_id, COALESCE(shared_with_id, owner_id))
-  base_match_player_id,
-  canonical_match_id,
-  canonical_player_id,
-  original_player_id,
-  linked_player_id,
-  shared_player_id,
-  shared_match_player_id,
-  owner_id,
-  shared_with_id,
-  source_type,
-  player_source_type,
-  permission,
-  team_id,
-  score,
-  winner,
-  placement,
-  created_at,
-  updated_at
-FROM unioned
-ORDER BY
-  base_match_player_id,
-  COALESCE(shared_with_id, owner_id),
-  CASE player_source_type
-    WHEN 'linked' THEN 1
-    WHEN 'shared' THEN 2
-    ELSE 3
-  END;
-
--- ============================================================
--- RECREATE v_game_match_overview
--- ============================================================
-CREATE OR REPLACE VIEW v_game_match_overview AS
-WITH ranked AS (
-  SELECT
-    vmc.visible_to_user_id,
-    vmc.canonical_game_id,
-    vmc.match_id,
-    vmc.match_date,
-    vmc.visibility_source,
-    vmc.permission,
-    COUNT(*) OVER (
-      PARTITION BY vmc.visible_to_user_id, vmc.canonical_game_id
-    ) AS match_count,
-    ROW_NUMBER() OVER (
-      PARTITION BY vmc.visible_to_user_id, vmc.canonical_game_id
-      ORDER BY vmc.match_date DESC, vmc.match_id DESC
-    ) AS rn
-  FROM v_match_canonical vmc
-)
-SELECT
-  r.visible_to_user_id,
-  r.canonical_game_id,
-  r.match_count,
-  r.match_id       AS latest_match_id,
-  r.match_date     AS latest_match_date,
-  r.visibility_source AS latest_visibility_source,
-  r.permission     AS latest_permission
-FROM ranked r
-WHERE r.rn = 1;
-
--- ============================================================
--- RECREATE v_scoresheet_analytics_for_user
--- ============================================================
+--> statement-breakpoint
 CREATE OR REPLACE VIEW v_scoresheet_analytics_for_user AS
 WITH RECURSIVE scoresheet_roots AS (
   SELECT
@@ -369,10 +170,7 @@ LEFT JOIN boardgames_shared_scoresheet source_shared_scoresheet
   ON source_shared_scoresheet.id = lsr.forked_from_shared_scoresheet_id
  AND source_shared_scoresheet.shared_with_id = vmc.visible_to_user_id
 WHERE m.deleted_at IS NULL;
-
--- ============================================================
--- RECREATE v_round_analytics_for_user
--- ============================================================
+--> statement-breakpoint
 CREATE OR REPLACE VIEW v_round_analytics_for_user AS
 WITH RECURSIVE round_roots AS (
   SELECT

--- a/packages/db/src/migrations/0007_scoresheet_materialized_shared_unique.sql
+++ b/packages/db/src/migrations/0007_scoresheet_materialized_shared_unique.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "boardgames_scoresheet_created_by_forked_from_shared_active_unique"
+ON "boardgames_scoresheet" ("created_by", "forked_from_shared_scoresheet_id")
+WHERE ("deleted_at" IS NULL AND "forked_from_shared_scoresheet_id" IS NOT NULL);

--- a/packages/db/src/relations/match.relations.ts
+++ b/packages/db/src/relations/match.relations.ts
@@ -74,6 +74,10 @@ export const matchRelations = defineRelationsPart(schema, (r) => ({
       from: r.round.id,
       to: r.sharedRound.linkedRoundId,
     }),
+    analyticsLinkedSharedRounds: r.many.sharedRound({
+      from: r.round.id,
+      to: r.sharedRound.analyticsLinkedRoundId,
+    }),
   },
   match: {
     creator: r.one.user({

--- a/packages/db/src/relations/scoresheet.relations.ts
+++ b/packages/db/src/relations/scoresheet.relations.ts
@@ -17,6 +17,14 @@ export const scoresheetRelations = defineRelationsPart(schema, (r) => ({
       from: r.scoresheet.id,
       to: r.sharedScoresheet.scoresheetId,
     }),
+    analyticsLinkedSharedScoresheets: r.many.sharedScoresheet({
+      from: r.scoresheet.id,
+      to: r.sharedScoresheet.analyticsLinkedScoresheetId,
+    }),
+    forkedFromSharedScoresheet: r.one.sharedScoresheet({
+      from: r.scoresheet.forkedFromSharedScoresheetId,
+      to: r.sharedScoresheet.id,
+    }),
     matches: r.many.match({
       from: r.scoresheet.id,
       to: r.match.scoresheetId,

--- a/packages/db/src/relations/shared.relations.ts
+++ b/packages/db/src/relations/shared.relations.ts
@@ -255,6 +255,10 @@ export const sharedRelations = defineRelationsPart(schema, (r) => ({
       from: r.sharedScoresheet.linkedScoresheetId,
       to: r.scoresheet.id,
     }),
+    analyticsLinkedScoresheet: r.one.scoresheet({
+      from: r.sharedScoresheet.analyticsLinkedScoresheetId,
+      to: r.scoresheet.id,
+    }),
     sharedGame: r.one.sharedGame({
       from: r.sharedScoresheet.sharedGameId,
       to: r.sharedGame.id,
@@ -268,6 +272,10 @@ export const sharedRelations = defineRelationsPart(schema, (r) => ({
     sharedRounds: r.many.sharedRound({
       from: r.sharedScoresheet.id,
       to: r.sharedRound.sharedScoresheetId,
+    }),
+    materializedScoresheets: r.many.scoresheet({
+      from: r.sharedScoresheet.id,
+      to: r.scoresheet.forkedFromSharedScoresheetId,
     }),
   },
   sharedRound: {
@@ -288,6 +296,10 @@ export const sharedRelations = defineRelationsPart(schema, (r) => ({
     }),
     linkedRound: r.one.round({
       from: r.sharedRound.linkedRoundId,
+      to: r.round.id,
+    }),
+    analyticsLinkedRound: r.one.round({
+      from: r.sharedRound.analyticsLinkedRoundId,
       to: r.round.id,
     }),
     sharedScoresheet: r.one.sharedScoresheet({

--- a/packages/db/src/schema/round.ts
+++ b/packages/db/src/schema/round.ts
@@ -64,7 +64,9 @@ const rounds = createTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (table) => [
+    index("boardgames_round_parent_id_index").on(table.parentId),
     index("boardgames_round_scoresheet_id_index").on(table.scoresheetId),
+    index("boardgames_round_deleted_at_index").on(table.deletedAt),
     index("boardgames_round_round_key_index").on(table.roundKey),
     uniqueIndex("boardgames_round_scoresheet_round_key_active_unique")
       .on(table.scoresheetId, table.roundKey)

--- a/packages/db/src/schema/scoresheet.ts
+++ b/packages/db/src/schema/scoresheet.ts
@@ -6,6 +6,7 @@ import {
   serial,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
@@ -78,6 +79,13 @@ const scoresheets = createTable(
     index("boardgames_scoresheet_forked_from_shared_scoresheet_id_index").on(
       table.forkedFromSharedScoresheetId,
     ),
+    uniqueIndex(
+      "boardgames_scoresheet_created_by_forked_from_shared_active_unique",
+    )
+      .on(table.createdBy, table.forkedFromSharedScoresheetId)
+      .where(
+        sql`${table.deletedAt} IS NULL AND ${table.forkedFromSharedScoresheetId} IS NOT NULL`,
+      ),
   ],
 );
 

--- a/packages/db/src/schema/scoresheet.ts
+++ b/packages/db/src/schema/scoresheet.ts
@@ -29,6 +29,7 @@ const scoresheets = createTable(
       "template_revision_of_scoresheet_id",
     ),
     forkedFromScoresheetId: integer("forked_from_scoresheet_id"),
+    forkedFromSharedScoresheetId: integer("forked_from_shared_scoresheet_id"),
     forkedFromGameId: integer("forked_from_game_id").references(() => game.id),
     forkedForMatchId: integer("forked_for_match_id"),
     name: varchar("name", { length: 256 }).notNull(),
@@ -72,6 +73,9 @@ const scoresheets = createTable(
   (table) => [
     index("boardgames_scoresheet_game_id_index").on(table.gameId),
     index("boardgames_scoresheet_scoresheet_key_index").on(table.scoresheetKey),
+    index("boardgames_scoresheet_forked_from_shared_scoresheet_id_index").on(
+      table.forkedFromSharedScoresheetId,
+    ),
   ],
 );
 

--- a/packages/db/src/schema/scoresheet.ts
+++ b/packages/db/src/schema/scoresheet.ts
@@ -72,6 +72,8 @@ const scoresheets = createTable(
   },
   (table) => [
     index("boardgames_scoresheet_game_id_index").on(table.gameId),
+    index("boardgames_scoresheet_parent_id_index").on(table.parentId),
+    index("boardgames_scoresheet_deleted_at_index").on(table.deletedAt),
     index("boardgames_scoresheet_scoresheet_key_index").on(table.scoresheetKey),
     index("boardgames_scoresheet_forked_from_shared_scoresheet_id_index").on(
       table.forkedFromSharedScoresheetId,

--- a/packages/db/src/schema/sharedRound.ts
+++ b/packages/db/src/schema/sharedRound.ts
@@ -20,6 +20,9 @@ const sharedRound = createTable(
       .references(() => round.id)
       .notNull(),
     linkedRoundId: integer("linked_round_id").references(() => round.id),
+    analyticsLinkedRoundId: integer("analytics_linked_round_id").references(
+      () => round.id,
+    ),
     sharedScoresheetId: integer("shared_scoresheet_id")
       .references(() => sharedScoresheet.id)
       .notNull(),
@@ -37,6 +40,9 @@ const sharedRound = createTable(
     index("boardgames_shared_round_round_id_index").on(table.roundId),
     index("boardgames_shared_round_linked_round_id_index").on(
       table.linkedRoundId,
+    ),
+    index("boardgames_shared_round_analytics_linked_round_id_index").on(
+      table.analyticsLinkedRoundId,
     ),
     index("boardgames_shared_round_shared_scoresheet_id_index").on(
       table.sharedScoresheetId,

--- a/packages/db/src/schema/sharedScoresheet.ts
+++ b/packages/db/src/schema/sharedScoresheet.ts
@@ -30,6 +30,9 @@ const sharedScoresheet = createTable(
     linkedScoresheetId: integer("linked_scoresheet_id").references(
       () => scoresheet.id,
     ),
+    analyticsLinkedScoresheetId: integer(
+      "analytics_linked_scoresheet_id",
+    ).references(() => scoresheet.id),
     sharedGameId: integer("shared_game_id")
       .references(() => sharedGame.id)
       .notNull(),
@@ -57,6 +60,9 @@ const sharedScoresheet = createTable(
       table.sharedWithId,
     ),
     index("boardgames_shared_scoresheet_id_index").on(table.id),
+    index(
+      "boardgames_shared_scoresheet_analytics_linked_scoresheet_id_index",
+    ).on(table.analyticsLinkedScoresheetId),
   ],
 );
 

--- a/packages/db/src/views/analytics.ts
+++ b/packages/db/src/views/analytics.ts
@@ -1,0 +1,342 @@
+import { boolean, integer, pgView, text } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+
+export const vScoresheetAnalyticsForUser = pgView(
+  "v_scoresheet_analytics_for_user",
+  {
+    visibleToUserId: text("visible_to_user_id").notNull(),
+    canonicalGameId: integer("canonical_game_id").notNull(),
+    sharedGameId: integer("shared_game_id"),
+    matchId: integer("match_id").notNull(),
+    sharedMatchId: integer("shared_match_id"),
+    finished: boolean("finished").notNull(),
+    matchScoresheetId: integer("match_scoresheet_id").notNull(),
+    visibleScoresheetId: integer("visible_scoresheet_id").notNull(),
+    visibleScoresheetSourceType: text("visible_scoresheet_source_type")
+      .$type<"local" | "shared">()
+      .notNull(),
+    analyticsGroupingScoresheetId: integer(
+      "analytics_grouping_scoresheet_id",
+    ).notNull(),
+    analyticsGroupingScoresheetSourceType: text(
+      "analytics_grouping_scoresheet_source_type",
+    )
+      .$type<"local" | "shared">()
+      .notNull(),
+    analyticsGroupingKey: text("analytics_grouping_key").notNull(),
+    linkageState: text("linkage_state")
+      .$type<"original" | "shared_unlinked" | "shared_linked">()
+      .notNull(),
+    forkSourceType: text("fork_source_type")
+      .$type<"local" | "shared_materialized" | "shared_incoming">()
+      .notNull(),
+  },
+).as(sql`
+  WITH RECURSIVE scoresheet_roots AS (
+    SELECT
+      s.id AS start_scoresheet_id,
+      s.id AS resolved_scoresheet_id,
+      s.parent_id,
+      s.type,
+      s.forked_from_shared_scoresheet_id,
+      0 AS depth
+    FROM boardgames_scoresheet s
+    WHERE s.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT
+      sr.start_scoresheet_id,
+      parent.id AS resolved_scoresheet_id,
+      parent.parent_id,
+      parent.type,
+      parent.forked_from_shared_scoresheet_id,
+      sr.depth + 1 AS depth
+    FROM scoresheet_roots sr
+    JOIN boardgames_scoresheet parent
+      ON parent.id = sr.parent_id
+    WHERE sr.type = 'Match'
+      AND sr.parent_id IS NOT NULL
+      AND parent.deleted_at IS NULL
+  ),
+  local_scoresheet_roots AS (
+    SELECT DISTINCT ON (start_scoresheet_id)
+      start_scoresheet_id,
+      resolved_scoresheet_id AS local_root_scoresheet_id,
+      forked_from_shared_scoresheet_id
+    FROM scoresheet_roots
+    WHERE type <> 'Match'
+       OR parent_id IS NULL
+    ORDER BY start_scoresheet_id, depth ASC
+  )
+  SELECT
+    vmc.visible_to_user_id,
+    vmc.canonical_game_id,
+    vmc.shared_game_id,
+    vmc.match_id,
+    vmc.shared_match_id,
+    vmc.finished,
+    m.scoresheet_id AS match_scoresheet_id,
+    CASE
+      WHEN vmc.visibility_source = 'shared' THEN visible_shared_scoresheet.id
+      ELSE lsr.local_root_scoresheet_id
+    END AS visible_scoresheet_id,
+    CASE
+      WHEN vmc.visibility_source = 'shared' THEN 'shared'::text
+      ELSE 'local'::text
+    END AS visible_scoresheet_source_type,
+    CASE
+      WHEN vmc.visibility_source = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN visible_shared_scoresheet.analytics_linked_scoresheet_id
+      WHEN vmc.visibility_source = 'shared'
+        THEN visible_shared_scoresheet.id
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        AND source_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN source_shared_scoresheet.analytics_linked_scoresheet_id
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        THEN source_shared_scoresheet.id
+      ELSE lsr.local_root_scoresheet_id
+    END AS analytics_grouping_scoresheet_id,
+    CASE
+      WHEN vmc.visibility_source = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN 'local'::text
+      WHEN vmc.visibility_source = 'shared'
+        THEN 'shared'::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        AND source_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN 'local'::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        THEN 'shared'::text
+      ELSE 'local'::text
+    END AS analytics_grouping_scoresheet_source_type,
+    CASE
+      WHEN vmc.visibility_source = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN 'local:' || visible_shared_scoresheet.analytics_linked_scoresheet_id::text
+      WHEN vmc.visibility_source = 'shared'
+        THEN 'shared:' || visible_shared_scoresheet.id::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        AND source_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN 'local:' || source_shared_scoresheet.analytics_linked_scoresheet_id::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        THEN 'shared:' || source_shared_scoresheet.id::text
+      ELSE 'local:' || lsr.local_root_scoresheet_id::text
+    END AS analytics_grouping_key,
+    CASE
+      WHEN vmc.visibility_source = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN 'shared_linked'::text
+      WHEN vmc.visibility_source = 'shared'
+        THEN 'shared_unlinked'::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        AND source_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        THEN 'shared_linked'::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        THEN 'shared_unlinked'::text
+      ELSE 'original'::text
+    END AS linkage_state,
+    CASE
+      WHEN vmc.visibility_source = 'shared' THEN 'shared_incoming'::text
+      WHEN source_shared_scoresheet.id IS NOT NULL
+        THEN 'shared_materialized'::text
+      ELSE 'local'::text
+    END AS fork_source_type
+  FROM v_match_canonical vmc
+  JOIN boardgames_match m
+    ON m.id = vmc.match_id
+  JOIN local_scoresheet_roots lsr
+    ON lsr.start_scoresheet_id = m.scoresheet_id
+  LEFT JOIN boardgames_shared_match sm
+    ON sm.id = vmc.shared_match_id
+  LEFT JOIN boardgames_shared_scoresheet match_shared_scoresheet
+    ON match_shared_scoresheet.id = sm.shared_scoresheet_id
+  LEFT JOIN boardgames_shared_scoresheet visible_shared_scoresheet
+    ON visible_shared_scoresheet.id = COALESCE(
+      match_shared_scoresheet.parent_id,
+      match_shared_scoresheet.id
+    )
+  LEFT JOIN boardgames_shared_scoresheet source_shared_scoresheet
+    ON source_shared_scoresheet.id = lsr.forked_from_shared_scoresheet_id
+   AND source_shared_scoresheet.shared_with_id = vmc.visible_to_user_id
+  WHERE m.deleted_at IS NULL
+`);
+
+export const vRoundAnalyticsForUser = pgView("v_round_analytics_for_user", {
+  visibleToUserId: text("visible_to_user_id").notNull(),
+  canonicalGameId: integer("canonical_game_id").notNull(),
+  matchId: integer("match_id").notNull(),
+  sharedMatchId: integer("shared_match_id"),
+  matchScoresheetId: integer("match_scoresheet_id").notNull(),
+  matchRoundId: integer("match_round_id").notNull(),
+  visibleScoresheetId: integer("visible_scoresheet_id").notNull(),
+  analyticsGroupingScoresheetId: integer(
+    "analytics_grouping_scoresheet_id",
+  ).notNull(),
+  visibleRoundId: integer("visible_round_id").notNull(),
+  visibleRoundSourceType: text("visible_round_source_type")
+    .$type<"local" | "shared">()
+    .notNull(),
+  analyticsGroupingRoundId: integer("analytics_grouping_round_id").notNull(),
+  analyticsGroupingRoundSourceType: text("analytics_grouping_round_source_type")
+    .$type<"local" | "shared">()
+    .notNull(),
+  analyticsGroupingRoundKey: text("analytics_grouping_round_key").notNull(),
+  linkageState: text("linkage_state")
+    .$type<"original" | "shared_unlinked" | "shared_linked">()
+    .notNull(),
+}).as(sql`
+  WITH RECURSIVE round_roots AS (
+    SELECT
+      r.id AS start_round_id,
+      r.id AS resolved_round_id,
+      r.parent_id,
+      r.template_round_id,
+      s.type AS scoresheet_type,
+      0 AS depth
+    FROM boardgames_round r
+    JOIN boardgames_scoresheet s
+      ON s.id = r.scoresheet_id
+    WHERE r.deleted_at IS NULL
+      AND s.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT
+      rr.start_round_id,
+      parent.id AS resolved_round_id,
+      parent.parent_id,
+      parent.template_round_id,
+      parent_scoresheet.type AS scoresheet_type,
+      rr.depth + 1 AS depth
+    FROM round_roots rr
+    JOIN boardgames_round parent
+      ON parent.id = rr.parent_id
+    JOIN boardgames_scoresheet parent_scoresheet
+      ON parent_scoresheet.id = parent.scoresheet_id
+    WHERE rr.scoresheet_type = 'Match'
+      AND rr.parent_id IS NOT NULL
+      AND parent.deleted_at IS NULL
+      AND parent_scoresheet.deleted_at IS NULL
+  ),
+  local_round_roots AS (
+    SELECT DISTINCT ON (start_round_id)
+      start_round_id,
+      resolved_round_id AS local_root_round_id
+    FROM round_roots
+    WHERE scoresheet_type <> 'Match'
+       OR parent_id IS NULL
+    ORDER BY start_round_id, depth ASC
+  )
+  SELECT
+    vsau.visible_to_user_id,
+    vsau.canonical_game_id,
+    vsau.match_id,
+    vsau.shared_match_id,
+    vsau.match_scoresheet_id,
+    match_round.id AS match_round_id,
+    vsau.visible_scoresheet_id,
+    vsau.analytics_grouping_scoresheet_id,
+    CASE
+      WHEN vsau.visible_scoresheet_source_type = 'shared' THEN visible_shared_round.id
+      ELSE lrr.local_root_round_id
+    END AS visible_round_id,
+    CASE
+      WHEN vsau.visible_scoresheet_source_type = 'shared' THEN 'shared'::text
+      ELSE 'local'::text
+    END AS visible_round_source_type,
+    CASE
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND visible_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN visible_shared_round.analytics_linked_round_id
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        THEN visible_shared_round.id
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        AND provenance_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND provenance_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN provenance_shared_round.analytics_linked_round_id
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        THEN provenance_shared_round.id
+      ELSE lrr.local_root_round_id
+    END AS analytics_grouping_round_id,
+    CASE
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND visible_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN 'local'::text
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        THEN 'shared'::text
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        AND provenance_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND provenance_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN 'local'::text
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        THEN 'shared'::text
+      ELSE 'local'::text
+    END AS analytics_grouping_round_source_type,
+    CASE
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND visible_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN 'local:' || visible_shared_round.analytics_linked_round_id::text
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        THEN 'shared:' || visible_shared_round.id::text
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        AND provenance_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND provenance_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN 'local:' || provenance_shared_round.analytics_linked_round_id::text
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        THEN 'shared:' || provenance_shared_round.id::text
+      ELSE 'local:' || lrr.local_root_round_id::text
+    END AS analytics_grouping_round_key,
+    CASE
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        AND visible_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND visible_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN 'shared_linked'::text
+      WHEN vsau.visible_scoresheet_source_type = 'shared'
+        THEN 'shared_unlinked'::text
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        AND provenance_shared_scoresheet.analytics_linked_scoresheet_id IS NOT NULL
+        AND provenance_shared_round.analytics_linked_round_id IS NOT NULL
+        THEN 'shared_linked'::text
+      WHEN provenance_shared_scoresheet.id IS NOT NULL
+        THEN 'shared_unlinked'::text
+      ELSE 'original'::text
+    END AS linkage_state
+  FROM v_scoresheet_analytics_for_user vsau
+  JOIN boardgames_round match_round
+    ON match_round.scoresheet_id = vsau.match_scoresheet_id
+   AND match_round.deleted_at IS NULL
+  JOIN local_round_roots lrr
+    ON lrr.start_round_id = match_round.id
+  LEFT JOIN boardgames_scoresheet local_visible_scoresheet
+    ON local_visible_scoresheet.id = vsau.visible_scoresheet_id
+   AND vsau.visible_scoresheet_source_type = 'local'
+  LEFT JOIN boardgames_round local_root_round
+    ON local_root_round.id = lrr.local_root_round_id
+  LEFT JOIN boardgames_shared_match sm
+    ON sm.id = vsau.shared_match_id
+  LEFT JOIN boardgames_shared_scoresheet match_shared_scoresheet
+    ON match_shared_scoresheet.id = sm.shared_scoresheet_id
+  LEFT JOIN boardgames_shared_scoresheet visible_shared_scoresheet
+    ON visible_shared_scoresheet.id = COALESCE(
+      match_shared_scoresheet.parent_id,
+      match_shared_scoresheet.id
+    )
+  LEFT JOIN boardgames_shared_round visible_shared_round
+    ON visible_shared_round.shared_scoresheet_id = visible_shared_scoresheet.id
+   AND visible_shared_round.round_id = COALESCE(match_round.parent_id, match_round.id)
+  LEFT JOIN boardgames_shared_scoresheet provenance_shared_scoresheet
+    ON provenance_shared_scoresheet.id = local_visible_scoresheet.forked_from_shared_scoresheet_id
+   AND provenance_shared_scoresheet.shared_with_id = vsau.visible_to_user_id
+  LEFT JOIN boardgames_shared_round provenance_shared_round
+    ON provenance_shared_round.shared_scoresheet_id = provenance_shared_scoresheet.id
+   AND provenance_shared_round.round_id = COALESCE(
+     local_root_round.parent_id,
+     local_root_round.template_round_id,
+     local_root_round.id
+   )
+`);

--- a/packages/db/src/views/index.ts
+++ b/packages/db/src/views/index.ts
@@ -1,3 +1,7 @@
+export {
+  vRoundAnalyticsForUser,
+  vScoresheetAnalyticsForUser,
+} from "./analytics";
 export { vGameMatchOverview, vGameRoleCanonical } from "./game";
 export { vMatchCanonical } from "./match";
 export { vMatchPlayerCanonicalForUser } from "./matchPlayer";


### PR DESCRIPTION
## ✅ Checklist

- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoresheet stats UI shows analytics family, contributing visible scoresheets, and contributing match counts; visible scoresheets shown with match counts.
  * Scoresheet grouping in the UI now follows analytics grouping keys for more consistent organization per user.
  * Shared scoresheets/rounds can be linked to local targets so analytics families can be merged or remain per-recipient.

* **Documentation**
  * Added guide describing the scoresheet analytics model, grouping rules, and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->